### PR TITLE
BXC-4808: Improve transfer reliaability

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/ProcessSourceFilesCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/ProcessSourceFilesCommand.java
@@ -10,7 +10,6 @@ import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import edu.unc.lib.boxc.migration.cdm.services.SourceFileService;
 import edu.unc.lib.boxc.migration.cdm.services.SourceFilesToRemoteService;
 import edu.unc.lib.boxc.migration.cdm.util.SshClientService;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import picocli.CommandLine;
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/util/SshClientService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/util/SshClientService.java
@@ -34,7 +34,8 @@ import static org.slf4j.LoggerFactory.getLogger;
  */
 public class SshClientService {
     private static final Logger log = getLogger(SshClientService.class);
-    private static final int SSH_TIMEOUT_SECONDS = 10;
+    private static final int SSH_TIMEOUT_SECONDS = 60 * 5;
+    private static final int AUTH_TIMEOUT_SECONDS = 10;
 
     private String sshHost;
     private int sshPort;
@@ -125,7 +126,7 @@ public class SshClientService {
                 .verify(SSH_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 .getSession()) {
             setupSessionAuthentication(sshSession);
-            sshSession.auth().verify(SSH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            sshSession.auth().verify(AUTH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             sshBlock.accept(sshSession);
         } catch (IOException e) {
             if (e instanceof SshException && e.getMessage().contains("No more authentication methods available")) {


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-4808

* Allow a much longer time for ssh timeouts, but keep timeout the same for auth
* Keep sessions alive for duration of thread, rather than a new one for every transfer. 
* Create all of the parent directories up front, rather than scattered throughout file transfers, and avoid extra calls. 
* Use futures so that we can get the error back from transfers and have the job fail rather than progress is a file doesn't transfer