### PR TITLE
BXC-4692 populate access surrogate mappings from boxctron

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/BoxctronFileCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/BoxctronFileCommand.java
@@ -1,0 +1,135 @@
+package edu.unc.lib.boxc.migration.cdm;
+
+import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.options.BoxctronFileMappingOptions;
+import edu.unc.lib.boxc.migration.cdm.options.GenerateSourceFileMappingOptions;
+import edu.unc.lib.boxc.migration.cdm.options.Verbosity;
+import edu.unc.lib.boxc.migration.cdm.services.AccessFileService;
+import edu.unc.lib.boxc.migration.cdm.services.BoxctronFileService;
+import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
+import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import edu.unc.lib.boxc.migration.cdm.status.AccessFilesStatusService;
+import edu.unc.lib.boxc.migration.cdm.status.SourceFilesSummaryService;
+import edu.unc.lib.boxc.migration.cdm.validators.AccessFilesValidator;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * @author krwong
+ */
+@Command(name = "boxctron_files",
+        description = "Commands related to boxctron access file mappings")
+public class BoxctronFileCommand {
+    private static final Logger log = getLogger(BoxctronFileCommand.class);
+
+    @ParentCommand
+    private CLIMain parentCommand;
+
+    private MigrationProject project;
+    private SourceFilesSummaryService summaryService;
+    private BoxctronFileService boxctronFileService;
+
+    @Command(name = "generate",
+            description = {
+                    "Generate the optional boxctron access copy mapping file for this project."})
+    public int generate(@Mixin BoxctronFileMappingOptions options) throws Exception {
+        long start = System.nanoTime();
+
+        try {
+            initialize(options.getDryRun());
+
+            summaryService.capturePreviousState();
+            boxctronFileService.generateMapping(options);
+            summaryService.summary(parentCommand.getVerbosity());
+            outputLogger.info("Boxctron access mapping generated for {} in {}s", project.getProjectName(),
+                    (System.nanoTime() - start) / 1e9);
+            return 0;
+        } catch (MigrationException | IllegalArgumentException e) {
+            outputLogger.info("Cannot generate boxctron access mapping: {}", e.getMessage());
+            return 1;
+        } catch (Exception e) {
+            log.error("Failed to map boxctron access files", e);
+            outputLogger.info("Failed to map boxctron access files: {}", e.getMessage(), e);
+            return 1;
+        }
+    }
+
+    @Command(name = "validate",
+            description = "Validate the boxctron access file mappings for this project")
+    public int validate(@Option(names = { "-f", "--force"},
+            description = "Ignore incomplete mappings") boolean force) throws Exception {
+        try {
+            initialize(false);
+            AccessFilesValidator validator = new AccessFilesValidator();
+            validator.setProject(project);
+            List<String> errors = validator.validateMappings(force);
+            if (errors.isEmpty()) {
+                outputLogger.info("PASS: Boxctron access file mapping at path {} is valid",
+                        project.getAccessFilesMappingPath());
+                return 0;
+            } else {
+                if (parentCommand.getVerbosity().equals(Verbosity.QUIET)) {
+                    outputLogger.info("FAIL: Boxctron access file mapping is invalid with {} errors", errors.size());
+                } else {
+                    outputLogger.info("FAIL: Boxctron access file mapping at path {} is invalid due to the following issues:",
+                            project.getAccessFilesMappingPath());
+                    for (String error : errors) {
+                        outputLogger.info("    - " + error);
+                    }
+                }
+                return 1;
+            }
+        } catch (MigrationException e) {
+            log.error("Failed to validate boxctron access file mappings", e);
+            outputLogger.info("FAIL: Failed to validate boxctron access file mappings: {}", e.getMessage());
+            return 1;
+        }
+    }
+
+    @Command(name = "status",
+            description = "Display status of the boxctron access file mappings for this project")
+    public int status() throws Exception {
+        try {
+            initialize(false);
+            AccessFilesStatusService statusService = new AccessFilesStatusService();
+            statusService.setProject(project);
+            statusService.report(parentCommand.getVerbosity());
+
+            return 0;
+        } catch (MigrationException | IllegalArgumentException e) {
+            outputLogger.info("Status failed: {}", e.getMessage());
+            return 1;
+        } catch (Exception e) {
+            log.error("Status failed", e);
+            outputLogger.info("Status failed: {}", e.getMessage(), e);
+            return 1;
+        }
+    }
+
+    private void initialize(boolean dryRun) throws IOException {
+        Path currentPath = parentCommand.getWorkingDirectory();
+        project = MigrationProjectFactory.loadMigrationProject(currentPath);
+        CdmIndexService indexService = new CdmIndexService();
+        indexService.setProject(project);
+        boxctronFileService = new BoxctronFileService();
+        boxctronFileService.setIndexService(indexService);
+        boxctronFileService.setProject(project);
+        summaryService = new SourceFilesSummaryService();
+        summaryService.setProject(project);
+        summaryService.setDryRun(dryRun);
+        summaryService.setSourceFileService(boxctronFileService);
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/CLIMain.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/CLIMain.java
@@ -45,7 +45,8 @@ import java.util.concurrent.Callable;
         ListProjectsCommand.class,
         ArchiveProjectsCommand.class,
         ProcessSourceFilesCommand.class,
-        AltTextCommand.class
+        AltTextCommand.class,
+        BoxctronFileCommand.class
     })
 public class CLIMain implements Callable<Integer> {
     @Option(names = { "-w", "--work-dir" },

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProject.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProject.java
@@ -30,6 +30,7 @@ public class MigrationProject {
     public static final String EXPORT_OBJECTS_FILENAME = "exported_objects.csv";
     public static final String ALT_TEXT_FILENAME = "alt_text.csv";
     public static final String ALT_TEXT_DIRNAME = "alt_text";
+    public static final String BOXCTRON_DATA_FILENAME = "processing/results/velocicroptor/output/data.csv";
 
     private Path projectPath;
     private MigrationProjectProperties properties;
@@ -195,5 +196,12 @@ public class MigrationProject {
      */
     public Path getAltTextPath() {
         return projectPath.resolve(ALT_TEXT_DIRNAME);
+    }
+
+    /**
+     * @return Path of the boxctron data.csv results
+     */
+    public Path getBoxctronDataPath() {
+        return projectPath.resolve(BOXCTRON_DATA_FILENAME);
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/BoxctronFileMappingOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/BoxctronFileMappingOptions.java
@@ -1,0 +1,50 @@
+package edu.unc.lib.boxc.migration.cdm.options;
+
+import picocli.CommandLine.Option;
+
+/**
+ * Options for boxctron file mapping
+ * @author krwong
+ */
+public class BoxctronFileMappingOptions {
+    @Option(names = {"-d", "--dry-run"},
+            description = {
+                    "If provided, then the output of the matching will be displayed in the console rather "
+                            + "than written to file"})
+    private boolean dryRun;
+
+    @Option(names = {"-u", "--update"},
+            description = {
+                    "If provided, then any source file matches produced will be used to update an existing"
+                            + " source file mapping file, instead of attempting to create a new one.",
+                    "This can be used to build up the mapping in multiple passes"})
+    private boolean update;
+
+    @Option(names = { "-f", "--force"},
+            description = "Overwrite mapping file if one already exists")
+    private boolean force;
+
+    public boolean getDryRun() {
+        return dryRun;
+    }
+
+    public void setDryRun(boolean dryRun) {
+        this.dryRun = dryRun;
+    }
+
+    public boolean getUpdate() {
+        return update;
+    }
+
+    public void setUpdate(boolean update) {
+        this.update = update;
+    }
+
+    public boolean isForce() {
+        return force;
+    }
+
+    public void setForce(boolean force) {
+        this.force = force;
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/options/BoxctronFileMappingOptions.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/options/BoxctronFileMappingOptions.java
@@ -15,8 +15,8 @@ public class BoxctronFileMappingOptions {
 
     @Option(names = {"-u", "--update"},
             description = {
-                    "If provided, then any source file matches produced will be used to update an existing"
-                            + " source file mapping file, instead of attempting to create a new one.",
+                    "If provided, then any boxctron access file matches produced will be used to update an existing"
+                            + " access file mapping file, instead of attempting to create a new one.",
                     "This can be used to build up the mapping in multiple passes"})
     private boolean update;
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/BoxctronFileService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/BoxctronFileService.java
@@ -1,0 +1,222 @@
+package edu.unc.lib.boxc.migration.cdm.services;
+
+import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
+import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
+import edu.unc.lib.boxc.migration.cdm.model.SourceFilesInfo;
+import edu.unc.lib.boxc.migration.cdm.model.SourceFilesInfo.SourceFileMapping;
+import edu.unc.lib.boxc.migration.cdm.options.BoxctronFileMappingOptions;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.io.FilenameUtils;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Service for interacting with boxctron access copy files
+ * Alternate method for popupating access surrogate mappings
+ * @author krwong
+ */
+public class BoxctronFileService extends AccessFileService {
+    public static final String ORIGINAL_PATH = "original_path";
+    public static final String PREDICTED_CLASS = "predicted_class";
+    public static final String PREDICTED_CONF = "predicted_conf";
+    public static final String BOUNDING_BOX = "bounding_box";
+    public static final String EXTENDED_BOX = "extended_box";
+    public static final String[] DATA_CSV_HEADERS = new String[] { ORIGINAL_PATH, PREDICTED_CLASS, PREDICTED_CONF,
+            BOUNDING_BOX, EXTENDED_BOX };
+
+    public BoxctronFileService() {}
+
+    /**
+     * Generate the boxctron source file mapping
+     * @throws IOException
+     */
+    public void generateMapping(BoxctronFileMappingOptions options) throws IOException {
+        assertProjectStateValid();
+
+        // Gather listing of all potential source file paths to match against
+        Map<String, String> candidatePaths = gatherCandidatePaths(project.getBoxctronDataPath());
+
+        Path mappingPath = getMappingPath();
+        boolean needsMerge = options.getUpdate() && Files.exists(mappingPath);
+        // Write to temp mappings file if doing a dry run, otherwise write to mappings file
+        if (needsMerge || options.getDryRun()) {
+            mappingPath = getTempMappingPath();
+        }
+        Files.deleteIfExists(mappingPath);
+
+        // Iterate through exported objects in this collection to match against
+        Connection conn = null;
+        try (var csvPrinter = openMappingsPrinter(mappingPath)) {
+            String query = "select " + CdmFieldInfo.CDM_ID + ", file"
+                    + " from " + CdmIndexService.TB_NAME;
+
+            conn = indexService.openDbConnection();
+            Statement stmt = conn.createStatement();
+            var rs = stmt.executeQuery(query);
+            while (rs.next()) {
+                if (!rs.getString(1).isEmpty() && !rs.getString(2).isEmpty()) {
+                    String cdmId = rs.getString(1);
+                    String filename = rs.getString(2);
+
+                    if (candidatePaths.containsKey(filename)) {
+                        String candidatePath = candidatePaths.get(filename);
+                        log.debug("Found match for {} from field {}", cdmId, candidatePath);
+                        csvPrinter.printRecord(cdmId, filename,
+                                computeAccessPath(candidatePath), null);
+                    } else {
+                        csvPrinter.printRecord(cdmId, filename, null, null);
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            throw new MigrationException("Error interacting with export index", e);
+        } finally {
+            CdmIndexService.closeDbConnection(conn);
+        }
+
+        // Performing update operation with existing mapping, need to merge values
+        if (needsMerge) {
+            mergeUpdates(options, mappingPath);
+        }
+
+        if (!options.getDryRun()) {
+            setUpdatedDate(Instant.now());
+        }
+    }
+
+    /**
+     * Read the data.csv produced by boxctron and
+     * gather original file paths if the predicted_class value is 1 (color bar detected)
+     * @throws Exception
+     */
+    private Map<String, String> gatherCandidatePaths(Path dataPath) throws IOException {
+        if (Files.notExists(dataPath)) {
+            throw new NoSuchFileException(dataPath + " does not exist");
+        }
+
+        Map<String, String> candidatePathsMap = new HashMap<>();
+        try (Reader reader = Files.newBufferedReader(dataPath);
+             CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
+                .withFirstRecordAsHeader()
+                .withHeader(DATA_CSV_HEADERS)
+                .withTrim());
+        ) {
+            for (CSVRecord csvRecord : csvParser) {
+                String originalPath = csvRecord.get(0);
+                String predictedClass = csvRecord.get(1);
+
+                if (predictedClass.contains("1")) {
+                    candidatePathsMap.put(FilenameUtils.getName(originalPath), originalPath);
+                }
+            }
+        } catch (IOException e) {
+            throw new MigrationException("Failed to read boxctron data file", e);
+        }
+        return candidatePathsMap;
+    }
+
+    private Path computeAccessPath(String originalPath) {
+        return project.getProjectPath().resolve("processing/results/velocicroptor/output" + originalPath + ".jpg");
+    }
+
+    /**
+     * Merge existing mappings with updated mappings, writing to temporary files as intermediates
+     * @param options
+     * @param updatesPath the temp path containing the newly generated mappings to merge into the original mappings
+     */
+    private void mergeUpdates(BoxctronFileMappingOptions options, Path updatesPath) throws IOException {
+        Path originalPath = getMappingPath();
+        Path mergedPath = originalPath.getParent().resolve("~" + originalPath.getFileName().toString() + "_merged");
+        // Cleanup temp merged path if it already exists
+        Files.deleteIfExists(mergedPath);
+
+        // Load the new mappings into memory
+        SourceFilesInfo updateInfo = loadMappings(updatesPath);
+
+        // Iterate through the existing mappings, merging in the updated mappings when appropriate
+        try (
+                var originalParser = openMappingsParser(originalPath);
+                // Write to temp mappings file if doing a dry run, otherwise write to mappings file
+                var mergedPrinter = openMappingsPrinter(mergedPath)
+        ) {
+            Set<String> origIds = new HashSet<>();
+            for (CSVRecord originalRecord : originalParser) {
+                var origMapping = recordToMapping(originalRecord);
+
+                SourceFileMapping updateMapping = updateInfo.getMappingByCdmId(origMapping.getCdmId());
+                if (updateMapping == null) {
+                    // No updates, so write original
+                    writeMapping(mergedPrinter, origMapping);
+                } else if (updateMapping.getSourcePaths() != null) {
+                    var resolvedMapping = resolveSourcePathConflict(options, origMapping, updateMapping);
+                    writeMapping(mergedPrinter, resolvedMapping);
+                } else if (updateMapping.getPotentialMatches() != null) {
+                    if (origMapping.getSourcePaths() != null) {
+                        // Prefer existing match, write original
+                        writeMapping(mergedPrinter, origMapping);
+                    } else {
+                        // merge potential matches
+                        if (origMapping.getPotentialMatches() != null) {
+                            Set<String> merged = Stream.concat(
+                                            origMapping.getPotentialMatches().stream(),
+                                            updateMapping.getPotentialMatches().stream())
+                                    .collect(Collectors.toSet());
+                            updateMapping.setPotentialMatches(new ArrayList<>(merged));
+                        }
+                        // Write entry with updated potential matches
+                        writeMapping(mergedPrinter, updateMapping);
+                    }
+                } else {
+                    // No change, retain original
+                    writeMapping(mergedPrinter, origMapping);
+                }
+                origIds.add(originalRecord.get(0));
+            }
+
+            // Add in any records that were updated but not present in the original document
+            Set<String> updateIds = updateInfo.getMappings().stream()
+                    .map(SourceFileMapping::getCdmId).collect(Collectors.toSet());
+            updateIds.removeAll(origIds);
+            for (String id : updateIds) {
+                writeMapping(mergedPrinter, updateInfo.getMappingByCdmId(id));
+            }
+        }
+
+        // swap the merged mappings to be the main mappings, unless we're doing a dry run
+        if (options.getDryRun()) {
+            Files.move(mergedPath, updatesPath, StandardCopyOption.REPLACE_EXISTING);
+        } else {
+            Files.move(mergedPath, originalPath, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    protected SourceFileMapping resolveSourcePathConflict(BoxctronFileMappingOptions options,
+                                                          SourceFileMapping origMapping,
+                                                          SourceFileMapping updateMapping) {
+        if (options.isForce() || origMapping.getSourcePaths() == null) {
+            // overwrite entry with updated mapping source path if using force or original didn't have match
+            return updateMapping;
+        } else {
+            // retain original source path
+            return origMapping;
+        }
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
@@ -64,6 +64,7 @@ public class SipService {
     private SourceFileService sourceFileService;
     private AccessFileService accessFileService;
     private AltTextService altTextService;
+    private BoxctronFileService boxctronFileService;
     private DescriptionsService descriptionsService;
     private RedirectMappingService redirectMappingService;
     private PremisLoggerFactory premisLoggerFactory;
@@ -104,6 +105,7 @@ public class SipService {
         workGeneratorFactory.setDescriptionsService(descriptionsService);
         workGeneratorFactory.setAccessFileService(accessFileService);
         workGeneratorFactory.setAltTextService(altTextService);
+        workGeneratorFactory.setBoxctronFileService(boxctronFileService);
         workGeneratorFactory.setRedirectMappingService(redirectMappingService);
         workGeneratorFactory.setPidMinter(pidMinter);
         workGeneratorFactory.setPostMigrationReportService(postMigrationReportService);
@@ -119,6 +121,11 @@ public class SipService {
             workGeneratorFactory.setAccessFilesInfo(accessFileService.loadMappings());
         } catch (NoSuchFileException e) {
             log.debug("No access mappings file, no access files will be added to the SIP");
+        }
+        try {
+            workGeneratorFactory.setAccessFilesInfo(boxctronFileService.loadMappings());
+        } catch (NoSuchFileException e) {
+            log.debug("No boxctron access mappings file, no boxctron access files will be added to the SIP");
         }
         try {
             workGeneratorFactory.setAltTextInfo(altTextService.loadMappings());
@@ -402,6 +409,10 @@ public class SipService {
 
     public void setAltTextService(AltTextService altTextService) {
         this.altTextService = altTextService;
+    }
+
+    public void setBoxctronFileService(BoxctronFileService boxctronFileService) {
+        this.boxctronFileService = boxctronFileService;
     }
 
     public void setDescriptionsService(DescriptionsService descriptionsService) {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileService.java
@@ -58,11 +58,11 @@ import static org.slf4j.LoggerFactory.getLogger;
  * @author bbpennel
  */
 public class SourceFileService {
-    private static final Logger log = getLogger(SourceFileService.class);
+    protected static final Logger log = getLogger(SourceFileService.class);
     private static final int FETCH_SIZE = 1000;
 
     protected MigrationProject project;
-    private CdmIndexService indexService;
+    protected CdmIndexService indexService;
 
     public SourceFileService() {
     }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGenerator.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGenerator.java
@@ -10,6 +10,7 @@ import edu.unc.lib.boxc.migration.cdm.model.SourceFilesInfo;
 import edu.unc.lib.boxc.migration.cdm.options.SipGenerationOptions;
 import edu.unc.lib.boxc.migration.cdm.services.AccessFileService;
 import edu.unc.lib.boxc.migration.cdm.services.AltTextService;
+import edu.unc.lib.boxc.migration.cdm.services.BoxctronFileService;
 import edu.unc.lib.boxc.migration.cdm.services.DescriptionsService;
 import edu.unc.lib.boxc.migration.cdm.services.PostMigrationReportService;
 import edu.unc.lib.boxc.migration.cdm.services.RedirectMappingService;
@@ -69,6 +70,7 @@ public class WorkGenerator {
     protected DescriptionsService descriptionsService;
     protected AccessFileService accessFileService;
     protected AltTextService altTextService;
+    protected BoxctronFileService boxctronFileService;
     protected PostMigrationReportService postMigrationReportService;
     protected PermissionsInfo permissionsInfo;
     protected StreamingMetadataService streamingMetadataService;

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGeneratorFactory.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGeneratorFactory.java
@@ -7,6 +7,7 @@ import edu.unc.lib.boxc.migration.cdm.options.SipGenerationOptions;
 import edu.unc.lib.boxc.migration.cdm.services.AccessFileService;
 import edu.unc.lib.boxc.migration.cdm.services.AggregateFileMappingService;
 import edu.unc.lib.boxc.migration.cdm.services.AltTextService;
+import edu.unc.lib.boxc.migration.cdm.services.BoxctronFileService;
 import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
 import edu.unc.lib.boxc.migration.cdm.services.DescriptionsService;
 import edu.unc.lib.boxc.migration.cdm.services.PostMigrationReportService;
@@ -28,6 +29,7 @@ public class WorkGeneratorFactory {
     private AccessFileService accessFileService;
     private AltTextInfo altTextInfo;
     private AltTextService altTextService;
+    private BoxctronFileService boxctronFileService;
     private Connection conn;
     private SipGenerationOptions options;
     private CdmToDestMapper cdmToDestMapper;
@@ -55,6 +57,7 @@ public class WorkGeneratorFactory {
         gen.sourceFilesInfo = sourceFilesInfo;
         gen.altTextInfo = altTextInfo;
         gen.altTextService = altTextService;
+        gen.boxctronFileService = boxctronFileService;
         gen.descriptionsService = descriptionsService;
         gen.conn = conn;
         gen.options = options;
@@ -104,6 +107,10 @@ public class WorkGeneratorFactory {
 
     public void setAltTextService(AltTextService altTextService) {
         this.altTextService = altTextService;
+    }
+
+    public void setBoxctronFileService(BoxctronFileService boxctronFileService) {
+        this.boxctronFileService = boxctronFileService;
     }
 
     public void setDescriptionsService(DescriptionsService descriptionsService) {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/AccessFilesCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/AccessFilesCommandIT.java
@@ -18,8 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author bbpennel
  */
 public class AccessFilesCommandIT extends AbstractCommandIT {
-
-
     private Path basePath;
 
     @BeforeEach

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/BoxctronFileCommandTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/BoxctronFileCommandTest.java
@@ -1,0 +1,113 @@
+package edu.unc.lib.boxc.migration.cdm;
+
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
+import edu.unc.lib.boxc.migration.cdm.services.BoxctronFileService;
+import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BoxctronFileCommandTest extends AbstractCommandIT {
+    private Path basePath;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        initProjectAndHelper();
+        basePath = tmpFolder;
+    }
+
+    @Test
+    public void generateNotIndexedTest() throws Exception {
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "boxctron_files", "generate"};
+        executeExpectFailure(args);
+
+        assertOutputContains("Project must be indexed");
+
+        assertUpdatedDateNotPresent();
+    }
+
+    @Test
+    public void generateBasicMatchSucceedsTest() throws Exception {
+        indexExportSamples();
+        String boxctronPath1 = "/mnt/projects/test_staging/mini_gilmer/276_182_E.tif";
+        boxctronWriteCsv(boxctronMappingBody(boxctronPath1 + ",1,0.9,\"[0.0, 0.9, 1.0, 1.0]\","));
+
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "boxctron_files", "generate"};
+        executeExpectSuccess(args);
+
+        assertTrue(Files.exists(project.getAccessFilesMappingPath()));
+        assertOutputMatches(".*Previous Files Mapped: +0.*");
+        assertOutputMatches(".*New Files Mapped: +1.*");
+        assertOutputMatches(".*Total Files Mapped: +1.*");
+        assertOutputMatches(".*Total Files in Project: +3.*");
+        Path accessPath1 = project.getProjectPath().resolve("processing/results/velocicroptor/output"
+                + boxctronPath1 + ".jpg");
+        assertOutputContains("25,276_182_E.tif," + accessPath1);
+
+        assertUpdatedDatePresent();
+    }
+
+    @Test
+    public void generateBasicMatchDryRunTest() throws Exception {
+        indexExportSamples();
+        String boxctronPath1 = "/mnt/projects/test_staging/mini_gilmer/276_182_E.tif";
+        boxctronWriteCsv(boxctronMappingBody(boxctronPath1 + ",1,0.9,\"[0.0, 0.9, 1.0, 1.0]\","));
+
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "boxctron_files", "generate",
+                "--dry-run"};
+        executeExpectSuccess(args);
+
+        assertFalse(Files.exists(project.getAccessFilesMappingPath()));
+        assertOutputMatches(".*Previous Files Mapped: +0.*");
+        assertOutputMatches(".*New Files Mapped: +1.*");
+        assertOutputMatches(".*Total Files Mapped: +1.*");
+        assertOutputMatches(".*Total Files in Project: +3.*");
+        Path accessPath1 = project.getProjectPath().resolve("processing/results/velocicroptor/output"
+                + boxctronPath1 + ".jpg");
+        assertOutputContains("25,276_182_E.tif," + accessPath1);
+
+        assertUpdatedDateNotPresent();
+    }
+
+    private void indexExportSamples() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+    }
+
+    private String boxctronMappingBody(String... rows) {
+        return String.join(",", BoxctronFileService.DATA_CSV_HEADERS) + "\n"
+                + String.join("\n", rows);
+    }
+
+    private void boxctronWriteCsv(String boxctronMappingBody) throws IOException {
+        FileUtils.write(project.getBoxctronDataPath().toFile(),
+                boxctronMappingBody, StandardCharsets.UTF_8);
+    }
+
+    private void assertUpdatedDatePresent() throws Exception {
+        MigrationProjectProperties props = ProjectPropertiesSerialization.read(project.getProjectPropertiesPath());
+        assertNotNull(props.getAccessFilesUpdatedDate(), "Updated timestamp must be set");
+        assertNull(props.getSourceFilesUpdatedDate(), "Source mapping timestamp must not be set");
+    }
+
+    private void assertUpdatedDateNotPresent() throws Exception {
+        MigrationProjectProperties props = ProjectPropertiesSerialization.read(project.getProjectPropertiesPath());
+        assertNull(props.getAccessFilesUpdatedDate(), "Updated timestamp must not be set");
+        assertNull(props.getSourceFilesUpdatedDate(), "Source mapping timestamp must not be set");
+    }
+}

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/BoxctronFileServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/BoxctronFileServiceTest.java
@@ -1,0 +1,219 @@
+package edu.unc.lib.boxc.migration.cdm.services;
+
+import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
+import edu.unc.lib.boxc.migration.cdm.model.SourceFilesInfo;
+import edu.unc.lib.boxc.migration.cdm.options.BoxctronFileMappingOptions;
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
+import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
+import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class BoxctronFileServiceTest {
+    private static final String PROJECT_NAME = "proj";
+
+    @TempDir
+    public Path tmpFolder;
+
+    private MigrationProject project;
+    private BoxctronFileService service;
+    private SipServiceHelper testHelper;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        project = MigrationProjectFactory.createCdmMigrationProject(
+                tmpFolder, PROJECT_NAME, null, "user",
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
+        Files.createDirectories(project.getExportPath());
+
+        testHelper = new SipServiceHelper(project, tmpFolder);
+
+        service = testHelper.getBoxctronFileService();
+        service.setProject(project);
+        service.setIndexService(testHelper.getIndexService());
+    }
+
+    @Test
+    public void generateNoIndexTest() throws Exception {
+        BoxctronFileMappingOptions options = new BoxctronFileMappingOptions();
+
+        try {
+            service.generateMapping(options);
+            fail();
+        } catch (InvalidProjectStateException e) {
+            assertExceptionContains("Project must be indexed", e);
+            assertMappedDateNotPresent();
+        }
+    }
+
+    @Test
+    public void generateBoxctronResultsDoNotExistTest() throws Exception {
+        setIndexedDate();
+        BoxctronFileMappingOptions options = new BoxctronFileMappingOptions();
+
+        try {
+            service.generateMapping(options);
+            fail();
+        } catch (NoSuchFileException e) {
+            assertExceptionContains("proj/processing/results/velocicroptor/output/data.csv does not exist", e);
+            assertMappedDateNotPresent();
+        }
+    }
+
+    @Test
+    public void generateNoSourceFilesTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        boxctronWriteCsv(boxctronMappingBody("/mnt/projects/test_staging/mini_gilmer/276_182_E.tif,0,0.0000,,"));
+        BoxctronFileMappingOptions options = new BoxctronFileMappingOptions();
+        service.generateMapping(options);
+
+        SourceFilesInfo info = service.loadMappings();
+        assertMappingPresent(info, "25", "276_182_E.tif", null);
+        assertMappingPresent(info, "26", "276_183_E.tif", null);
+        assertMappingPresent(info, "27", "276_203_E.tif", null);
+
+        assertMappedDatePresent();
+    }
+
+    @Test
+    public void generateExactMatchTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        String boxctronPath1 = "/mnt/projects/test_staging/mini_gilmer/276_182_E.tif";
+        boxctronWriteCsv(boxctronMappingBody(boxctronPath1 + ",1,0.9,\"[0.0, 0.9, 1.0, 1.0]\","));
+        BoxctronFileMappingOptions options = new BoxctronFileMappingOptions();
+
+        service.generateMapping(options);
+
+        SourceFilesInfo info = service.loadMappings();
+        Path accessPath1 = project.getProjectPath().resolve("processing/results/velocicroptor/output" + boxctronPath1 + ".jpg");
+        assertMappingPresent(info, "25", "276_182_E.tif", accessPath1);
+        assertMappingPresent(info, "26", "276_183_E.tif", null);
+        assertMappingPresent(info, "27", "276_203_E.tif", null);
+
+        assertMappedDatePresent();
+    }
+
+    @Test
+    public void generateDryRunSummaryTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        String boxctronPath1 = "/mnt/projects/test_staging/mini_gilmer/276_182_E.tif";
+        boxctronWriteCsv(boxctronMappingBody(boxctronPath1 + ",1,0.9,\"[0.0, 0.9, 1.0, 1.0]\","));
+        BoxctronFileMappingOptions options = new BoxctronFileMappingOptions();
+        options.setDryRun(true);
+
+        service.generateMapping(options);
+
+        assertFalse(Files.exists(project.getSourceFilesMappingPath()));
+        assertMappedDateNotPresent();
+    }
+
+    @Test
+    public void generateUpdateNoExistingFileTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        String boxctronPath1 = "/mnt/projects/test_staging/mini_gilmer/276_182_E.tif";
+        boxctronWriteCsv(boxctronMappingBody(boxctronPath1 + ",1,0.9,\"[0.0, 0.9, 1.0, 1.0]\","));
+        BoxctronFileMappingOptions options = new BoxctronFileMappingOptions();
+        options.setUpdate(true);
+
+        service.generateMapping(options);
+
+        SourceFilesInfo info = service.loadMappings();
+        Path accessPath1 = project.getProjectPath().resolve("processing/results/velocicroptor/output" + boxctronPath1 + ".jpg");
+        assertMappingPresent(info, "25", "276_182_E.tif", accessPath1);
+        assertMappingPresent(info, "26", "276_183_E.tif", null);
+        assertMappingPresent(info, "27", "276_203_E.tif", null);
+
+        assertMappedDatePresent();
+    }
+
+    @Test
+    public void generateUpdateExistingNoChangesTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        String boxctronPath1 = "/mnt/projects/test_staging/mini_gilmer/276_182_E.tif";
+        boxctronWriteCsv(boxctronMappingBody(boxctronPath1 + ",1,0.9,\"[0.0, 0.9, 1.0, 1.0]\","));
+        BoxctronFileMappingOptions options = new BoxctronFileMappingOptions();
+        service.generateMapping(options);
+
+        SourceFilesInfo info = service.loadMappings();
+        Path accessPath1 = project.getProjectPath().resolve("processing/results/velocicroptor/output" + boxctronPath1 + ".jpg");
+        assertMappingPresent(info, "25", "276_182_E.tif", accessPath1);
+        assertMappingPresent(info, "26", "276_183_E.tif", null);
+        assertMappingPresent(info, "27", "276_203_E.tif", null);
+
+        assertMappedDatePresent();
+
+        options.setUpdate(true);
+        service.generateMapping(options);
+
+        SourceFilesInfo info2 = service.loadMappings();
+        Path accessPath2 = project.getProjectPath().resolve("processing/results/velocicroptor/output" + boxctronPath1 + ".jpg");
+        assertMappingPresent(info, "25", "276_182_E.tif", accessPath2);
+        assertMappingPresent(info2, "26", "276_183_E.tif", null);
+        assertMappingPresent(info2, "27", "276_203_E.tif", null);
+    }
+
+    private void setIndexedDate() throws Exception {
+        project.getProjectProperties().setIndexedDate(Instant.now());
+        ProjectPropertiesSerialization.write(project);
+    }
+
+    private void assertMappingPresent(SourceFilesInfo info, String cdmid, String matchingVal, Path sourcePath,
+                                      Path... potentialPaths) {
+        List<SourceFilesInfo.SourceFileMapping> mappings = info.getMappings();
+        SourceFilesInfo.SourceFileMapping mapping = mappings.stream().filter(m -> m.getCdmId().equals(cdmid)).findFirst().get();
+
+        assertEquals(sourcePath, mapping.getFirstSourcePath());
+        assertEquals(matchingVal, mapping.getMatchingValue());
+        if (potentialPaths.length > 0) {
+            for (Path potentialPath : potentialPaths) {
+                assertTrue(mapping.getPotentialMatches().contains(potentialPath.toString()),
+                        "Mapping did not contain expected potential path: " + potentialPath);
+            }
+        }
+    }
+
+    private void assertExceptionContains(String expected, Exception e) {
+        assertTrue(e.getMessage().contains(expected),
+                "Expected message exception to contain '" + expected + "', but was: " + e.getMessage());
+    }
+
+    private void assertMappedDatePresent() throws Exception {
+        MigrationProjectProperties props = ProjectPropertiesSerialization.read(project.getProjectPropertiesPath());
+        assertNotNull(props.getAccessFilesUpdatedDate());
+    }
+
+    private void assertMappedDateNotPresent() throws Exception {
+        MigrationProjectProperties props = ProjectPropertiesSerialization.read(project.getProjectPropertiesPath());
+        assertNull(props.getAccessFilesUpdatedDate());
+    }
+
+    private String boxctronMappingBody(String... rows) {
+        return String.join(",", BoxctronFileService.DATA_CSV_HEADERS) + "\n"
+                + String.join("\n", rows);
+    }
+
+    private void boxctronWriteCsv(String boxctronMappingBody) throws IOException {
+        FileUtils.write(project.getBoxctronDataPath().toFile(),
+                boxctronMappingBody, StandardCharsets.UTF_8);
+    }
+}

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/SourceFileServiceTest.java
@@ -736,8 +736,6 @@ public class SourceFileServiceTest {
         assertEquals(2, info.getMappings().size());
     }
 
-
-
     private void assertMappingPresent(SourceFilesInfo info, String cdmid, String matchingVal, Path sourcePath,
                                       Path... potentialPaths) {
         List<SourceFileMapping> mappings = info.getMappings();

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/test/SipServiceHelper.java
@@ -21,12 +21,14 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import edu.unc.lib.boxc.auth.api.UserRole;
+import edu.unc.lib.boxc.migration.cdm.options.BoxctronFileMappingOptions;
 import edu.unc.lib.boxc.migration.cdm.options.CdmIndexOptions;
 import edu.unc.lib.boxc.migration.cdm.options.GenerateSourceFileMappingOptions;
 import edu.unc.lib.boxc.migration.cdm.options.PermissionMappingOptions;
 import edu.unc.lib.boxc.migration.cdm.services.AggregateFileMappingService;
 import edu.unc.lib.boxc.migration.cdm.services.AltTextService;
 import edu.unc.lib.boxc.migration.cdm.services.ArchivalDestinationsService;
+import edu.unc.lib.boxc.migration.cdm.services.BoxctronFileService;
 import edu.unc.lib.boxc.migration.cdm.services.CdmFileRetrievalService;
 import edu.unc.lib.boxc.migration.cdm.services.ChompbConfigService;
 import edu.unc.lib.boxc.migration.cdm.services.ExportObjectsService;
@@ -90,6 +92,7 @@ public class SipServiceHelper {
     private AltTextService altTextService;
     private AggregateFileMappingService aggregateFileMappingService;
     private AggregateFileMappingService aggregateBottomMappingService;
+    private BoxctronFileService boxctronFileService;
     private DescriptionsService descriptionsService;
     private DestinationsService destinationsService;
     private ArchivalDestinationsService archivalDestinationsService;
@@ -135,6 +138,9 @@ public class SipServiceHelper {
         archivalDestinationsService.setProject(project);
         archivalDestinationsService.setIndexService(indexService);
         archivalDestinationsService.setDestinationsService(destinationsService);
+        boxctronFileService = new BoxctronFileService();
+        boxctronFileService.setProject(project);
+        boxctronFileService.setIndexService(indexService);
         permissionsService = new PermissionsService();
         permissionsService.setProject(project);
         streamingMetadataService = new StreamingMetadataService();
@@ -150,6 +156,7 @@ public class SipServiceHelper {
         service.setIndexService(indexService);
         service.setAccessFileService(accessFileService);
         service.setAltTextService(altTextService);
+        service.setBoxctronFileService(boxctronFileService);
         service.setSourceFileService(sourceFileService);
         service.setPidMinter(pidMinter);
         service.setDescriptionsService(descriptionsService);
@@ -392,6 +399,24 @@ public class SipServiceHelper {
         return sourcePaths;
     }
 
+    public void populateBoxctronFiles(String boxctronPath1, String boxctronPath2) throws Exception {
+        boxctronWriteCsv(boxctronMappingBody(boxctronPath1 + ",1,0.9,\"[0.0, 0.9, 1.0, 1.0]\",",
+                boxctronPath2 + ",1,0.9,\"[0.0, 0.9, 1.0, 1.0]\","));
+        BoxctronFileMappingOptions options = new BoxctronFileMappingOptions();
+        options.setUpdate(true);
+        boxctronFileService.generateMapping(options);
+    }
+
+    private String boxctronMappingBody(String... rows) {
+        return String.join(",", BoxctronFileService.DATA_CSV_HEADERS) + "\n"
+                + String.join("\n", rows);
+    }
+
+    private void boxctronWriteCsv(String mappingBody) throws IOException {
+        FileUtils.write(project.getBoxctronDataPath().toFile(),
+                mappingBody, StandardCharsets.UTF_8);
+    }
+
     public GenerateSourceFileMappingOptions makeSourceFileOptions(Path basePath) {
         GenerateSourceFileMappingOptions options = new GenerateSourceFileMappingOptions();
         options.setBasePath(basePath);
@@ -556,6 +581,15 @@ public class SipServiceHelper {
             this.aggregateBottomMappingService.setIndexService(indexService);
         }
         return this.aggregateBottomMappingService;
+    }
+
+    public BoxctronFileService getBoxctronFileService() {
+        if (this.boxctronFileService == null) {
+            this.boxctronFileService = new BoxctronFileService();
+            this.boxctronFileService.setProject(project);
+            this.boxctronFileService.setIndexService(indexService);
+        }
+        return this.boxctronFileService;
     }
 
     public GroupMappingService getGroupMappingService() {


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4692](https://unclibrary.atlassian.net/browse/BXC-4692)

- `boxctron_files` service and command to populate the access surrogate mappings from boxctron data.csv
- add boxctron files to sips
- add `getBoxctronDataPath` to MigrationProject