### PR TITLE
BXC-3508 chompb finding aid report command

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/CdmFieldsCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/CdmFieldsCommand.java
@@ -14,6 +14,7 @@ import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import org.slf4j.Logger;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Option;
 
 /**
  * @author bbpennel
@@ -72,7 +73,8 @@ public class CdmFieldsCommand {
 
     @Command(name = "generate_field_url_report",
             description = "Generate an informational list of CDM fields with URLs")
-    public int generateFieldsAndUrlsReport() throws Exception {
+    public int generateFieldsAndUrlsReport(@Option(names = { "-fa", "--finding-aids" },
+            description = "Generate finding aid url report") boolean findingAid) throws Exception {
         try {
             MigrationProject project = MigrationProjectFactory
                     .loadMigrationProject(parentCommand.getWorkingDirectory());
@@ -80,7 +82,7 @@ public class CdmFieldsCommand {
             fieldUrlAssessmentService.setIndexService(indexService);
             fieldUrlAssessmentService.setCdmFieldService(fieldService);
             indexService.setProject(project);
-            fieldUrlAssessmentService.generateReport();
+            fieldUrlAssessmentService.generateReport(findingAid);
             outputLogger.info("Fields with URLs report generated!");
             return 0;
         } catch (MigrationException | IllegalArgumentException e) {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/FindingAidReportCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/FindingAidReportCommand.java
@@ -78,7 +78,12 @@ public class FindingAidReportCommand {
     }
 
     @Command(name = "collection_report",
-            description = {"Generate the report of finding aid hookids and lists counts"})
+            description = {"Generate the collection report to assess collection for associations with finding aids",
+                "Lists current collection number and hook id. If collection number is set," +
+                        " displays a list of unique collection numbers.",
+                "If collection number is not set, scan other fields for potential collection ids and list several.",
+                "Also displays percentage of records with the following fields populated: collec, descri, findin, " +
+                        "locati, title, prefer, creato, contri, relatid"})
     public int collectionReport() throws Exception {
         long start = System.nanoTime();
 

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/FindingAidReportCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/FindingAidReportCommand.java
@@ -3,6 +3,7 @@ package edu.unc.lib.boxc.migration.cdm;
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.options.FindingAidReportOptions;
+import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
 import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
 import edu.unc.lib.boxc.migration.cdm.services.FindingAidReportService;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
@@ -29,6 +30,7 @@ public class FindingAidReportCommand {
     private CLIMain parentCommand;
 
     private MigrationProject project;
+    private CdmFieldService fieldService;
     private CdmIndexService indexService;
     private FindingAidReportService reportService;
 
@@ -75,13 +77,37 @@ public class FindingAidReportCommand {
         }
     }
 
+    @Command(name = "collection_report",
+            description = {"Generate the report of finding aid hookids and lists counts"})
+    public int collectionReport() throws Exception {
+        long start = System.nanoTime();
+
+        try {
+            initialize();
+            reportService.collectionReport();
+            outputLogger.info("Generated collection report for {} in {}s", project.getProjectName(),
+                    (System.nanoTime() - start) / 1e9);
+            return 0;
+        } catch (MigrationException | IllegalArgumentException e) {
+            outputLogger.info("Cannot generate collection report: {}", e.getMessage());
+            return 1;
+        } catch (Exception e) {
+            log.error("Failed to generate collection report", e);
+            outputLogger.info("Failed to generate collection report: {}", e.getMessage(), e);
+            return 1;
+        }
+    }
+
     private void initialize() throws IOException {
         Path currentPath = parentCommand.getWorkingDirectory();
         project = MigrationProjectFactory.loadMigrationProject(currentPath);
+        fieldService = new CdmFieldService();
+        fieldService.setProject(project);
         indexService = new CdmIndexService();
         indexService.setProject(project);
         reportService = new FindingAidReportService();
         reportService.setProject(project);
+        reportService.setFieldService(fieldService);
         reportService.setIndexService(indexService);
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/FindingAidReportService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/FindingAidReportService.java
@@ -2,6 +2,7 @@ package edu.unc.lib.boxc.migration.cdm.services;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
+import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.options.FindingAidReportOptions;
 import org.apache.commons.csv.CSVFormat;
@@ -12,8 +13,16 @@ import java.io.BufferedWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 
+import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.repeat;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -22,12 +31,17 @@ import static org.slf4j.LoggerFactory.getLogger;
  */
 public class FindingAidReportService {
     private static final Logger log = getLogger(FindingAidReportService.class);
+    protected static final String INDENT = "    ";
+    private static final int MIN_LABEL_WIDTH = 20;
+    private static final int PROGRESS_BAR_UNITS = 40;
+    private static final double PROGRESS_BAR_DIVISOR = (double) 100 / PROGRESS_BAR_UNITS;
     public static final String FIELD_VALUES_REPORT = "_report.csv";
     public static final String HOOK_ID_REPORT = "hookid_report.csv";
     public static final String[] HOOKID_CSV_HEADERS = new String[] {FindingAidService.HOOK_ID_FIELD_DESC, "count"};
 
     private MigrationProject project;
     private CdmIndexService indexService;
+    private CdmFieldService fieldService;
 
     /**
      * Generate the report of unique values and counts of a given field
@@ -102,6 +116,156 @@ public class FindingAidReportService {
         return project.getProjectPath().resolve(HOOK_ID_REPORT);
     }
 
+    /**
+     * Report to assess collection for finding aid associations
+     */
+    public void collectionReport() {
+        assertProjectStateValid();
+        int totalRecords = countRecords("select count(*)" + " from " + CdmIndexService.TB_NAME);
+
+        if (project.getProjectProperties().getHookId() != null
+                || project.getProjectProperties().getCollectionNumber() != null) {
+            String hookId = project.getProjectProperties().getHookId();
+            String collectionNumber = project.getProjectProperties().getCollectionNumber();
+
+            List<String> uniqueCollectionIds = listCollectionIds();
+            int collectionIdRecords = countRecords("select count('" + FindingAidService.CONTRI_FIELD
+                    + "')" + " from " + CdmIndexService.TB_NAME);
+            int hookIdRecords = countRecords("select count('" + FindingAidService.DESCRI_FIELD
+                    + "')" + " from " + CdmIndexService.TB_NAME);
+
+            showField("Hook id", hookId);
+            showField("Collection number", collectionNumber);
+            showFieldListValues(uniqueCollectionIds);
+            showFieldWithPercent("Records with collection ids", collectionIdRecords, totalRecords);
+            showFieldWithPercent("Records with hook ids", hookIdRecords, totalRecords);
+        } else {
+            outputLogger.info("{}{}", INDENT, "Collection number is not set.");
+            outputLogger.info("{}{}", INDENT, "Possible collection numbers:");
+            List<String> potentialCollectionIds = listPotentialCollectionIds();
+            showFieldListValues(potentialCollectionIds);
+        }
+
+        outputLogger.info("{}{}", INDENT, "Fields populated:");
+        List<String> fieldsToReport = Arrays.asList("collec", "descri", "findin", "locati", "title", "prefer",
+                "creato", "contri", "relatid");
+        for (String field : fieldsToReport) {
+            String query = "select count(*)" + " from (select '" + field + "' from " + CdmIndexService.TB_NAME
+                    + " where '" + field + "' is not null or trim('" + field + "') != '')";
+//            String query = "select count('" + field + "')" + " from " + CdmIndexService.TB_NAME;
+//            + " where " + field + " is not null
+//             or trim('" + field + "') != ''
+//             or length(trim('" + field + "')) != 0";
+            int fieldRecords = countRecords(query);
+            displayProgressWithLabel(field, fieldRecords, totalRecords);
+        }
+    }
+
+    /**
+     * List of unique collection id values
+     */
+    private List<String> listCollectionIds() {
+        String collectionIdQuery = "select distinct " + FindingAidService.DESCRI_FIELD
+                + " from " + CdmIndexService.TB_NAME;
+        List<String> uniqueCollectionIds = new ArrayList<>();
+
+        try (Connection conn = indexService.openDbConnection()) {
+            var stmt = conn.createStatement();
+            var rs = stmt.executeQuery(collectionIdQuery);
+            while (rs.next()) {
+                if (!rs.getString(1).isBlank()) {
+                    uniqueCollectionIds.add(rs.getString(1));
+                }
+            }
+            return uniqueCollectionIds;
+        } catch (SQLException e) {
+            throw new MigrationException("Error interacting with export index", e);
+        }
+    }
+
+    /**
+     * Count records for a given query
+     */
+    private Integer countRecords(String query) {
+        try (Connection conn = indexService.openDbConnection()) {
+            var stmt = conn.createStatement();
+            var rs = stmt.executeQuery(query);
+            rs.next();
+            return rs.getInt(1);
+        } catch (SQLException e) {
+            throw new MigrationException("Error interacting with export index", e);
+        }
+    }
+
+    /**
+     * List of potential collection id values
+     */
+    private List<String> listPotentialCollectionIds() {
+        fieldService.validateFieldsFile(project);
+        CdmFieldInfo fieldInfo = fieldService.loadFieldsFromProject(project);
+        List<String> exportFields = fieldInfo.listAllExportFields();
+
+        List<String> potentialCollectionIds = new ArrayList<>();
+        // only collect the first 10 potential ids
+        int i = 0;
+        try (Connection conn = indexService.openDbConnection()) {
+            var stmt = conn.createStatement();
+            for (String field : exportFields) {
+                ResultSet rs = stmt.executeQuery(" select '" + field + "' from " + CdmIndexService.TB_NAME
+                        + " where '" + field + "' like " + "'^[A-Za-z0-9]{5}-?z?$'");
+                while (rs.next()) {
+                    if (!rs.getString(1).isBlank() && i < 10) {
+                        potentialCollectionIds.add(rs.getString(1));
+                        i++;
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            throw new MigrationException("Error interacting with export index", e);
+        }
+
+        if (potentialCollectionIds.isEmpty()) {
+            potentialCollectionIds.add("no potential collection ids found");
+        }
+        return potentialCollectionIds;
+    }
+
+    protected void showField(String label, Object value) {
+        int padding = MIN_LABEL_WIDTH - label.length();
+        outputLogger.info("{}{}: {}{}", INDENT, label, repeat(' ', padding), value);
+    }
+
+    protected void showFieldListValues(Collection<String> values) {
+        for (String value : values) {
+            outputLogger.info("{}{}* {}", INDENT, INDENT, value);
+        }
+    }
+
+    protected void showFieldWithPercent(String label, int value, int total) {
+        int padding = MIN_LABEL_WIDTH - label.length();
+        double percent = (double) value / total * 100;
+        outputLogger.info("{}{}: {}{} ({}%)", INDENT, label, repeat(' ', padding),
+                value, format("%.1f", percent));
+    }
+
+    protected void displayProgressWithLabel(String label, long current, long total) {
+        int padding = 10 - label.length();
+        long percent = Math.round(((float) current / total) * 100);
+        int progressBars = (int) Math.round(percent / PROGRESS_BAR_DIVISOR);
+
+        StringBuilder sb = new StringBuilder("\r");
+        sb.append(INDENT).append(INDENT).append(label).append(":").append(repeat(' ', padding)).append("|");
+        sb.append(repeat("=", progressBars));
+        sb.append(repeat(" ", PROGRESS_BAR_UNITS - progressBars));
+        sb.append("|  ").append(current).append("/").append(total).append("  |  ");
+        sb.append(format("%1$3s", percent)).append("%");;
+        // Append spaces to clear rest of line
+        sb.append(repeat(" ", 40));
+        sb.append("\r");
+
+        outputLogger.info(sb.toString());
+    }
+
     protected void assertProjectStateValid() {
         if (project.getProjectProperties().getIndexedDate() == null) {
             throw new InvalidProjectStateException("Project must be indexed prior to generating finding aid reports");
@@ -122,5 +286,9 @@ public class FindingAidReportService {
 
     public void setIndexService(CdmIndexService indexService) {
         this.indexService = indexService;
+    }
+
+    public void setFieldService(CdmFieldService fieldService) {
+        this.fieldService = fieldService;
     }
 }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmFieldsCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/CdmFieldsCommandIT.java
@@ -2,12 +2,8 @@ package edu.unc.lib.boxc.migration.cdm;
 
 import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
 import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo.CdmFieldEntry;
-import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
 import edu.unc.lib.boxc.migration.cdm.services.FieldAssessmentTemplateService;
-import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
-import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
-import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -102,6 +98,22 @@ public class CdmFieldsCommandIT extends AbstractCommandIT {
         String[] cmdArgs = new String[] {
                 "-w", projectPath.toString(),
                 "fields", "generate_field_url_report"};
+        executeExpectSuccess(cmdArgs);
+
+        assertTrue(Files.exists(reportPath));
+    }
+
+    @Test
+    public void generateFindingAidUrlReportTest() throws Exception {
+        initProjectAndHelper();
+        testHelper.indexExportData("03883");
+
+        Path projectPath = project.getProjectPath();
+        Path reportPath = projectPath.resolve("my_proj_finding_aid_urls.csv");
+
+        String[] cmdArgs = new String[] {
+                "-w", projectPath.toString(),
+                "fields", "generate_field_url_report", "-fa"};
         executeExpectSuccess(cmdArgs);
 
         assertTrue(Files.exists(reportPath));

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/FindingAidReportCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/FindingAidReportCommandIT.java
@@ -1,10 +1,13 @@
 package edu.unc.lib.boxc.migration.cdm;
 
+import edu.unc.lib.boxc.migration.cdm.services.CdmFieldService;
+import edu.unc.lib.boxc.migration.cdm.services.FindingAidService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -48,5 +51,36 @@ public class FindingAidReportCommandIT extends AbstractCommandIT {
         executeExpectSuccess(args);
 
         assertTrue(Files.exists(project.getProjectPath().resolve("hookid_report.csv")));
+    }
+
+    @Test
+    public void collectionReportTest() throws Exception {
+        Files.copy(Paths.get("src/test/resources/roy_brown/cdm_fields.csv"), project.getFieldsPath());
+        CdmFieldService fieldService = new CdmFieldService();
+        FindingAidService findingAidService = new FindingAidService();
+        findingAidService.setCdmFieldService(fieldService);
+        findingAidService.setProject(project);
+        findingAidService.recordFindingAid();
+        testHelper.indexExportData("03883");
+
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "finding_aid_reports", "collection_report"};
+        executeExpectSuccess(args);
+
+        assertOutputMatches(".*Hook id: +contri+.*");
+        assertOutputMatches(".*Collection number: +descri+.*");
+        assertOutputMatches(".*03883.*");
+        assertOutputMatches(".*Records with collection ids: +3 \\(100.0%\\).*");
+        assertOutputMatches(".*Records with hook ids: +3 \\(100.0%\\).*");
+        assertOutputMatches(".*collec:.*3\\/3.*100%.*");
+        assertOutputMatches(".*descri:.*3\\/3.*100%.*");
+        assertOutputMatches(".*findin:.*3\\/3.*100%.*");
+        assertOutputMatches(".*locati:.*3\\/3.*100%.*");
+        assertOutputMatches(".*title:.*3\\/3.*100%.*");
+        assertOutputMatches(".*prefer:.*3\\/3.*100%.*");
+        assertOutputMatches(".*creato:.*3\\/3.*100%.*");
+        assertOutputMatches(".*contri:.*3\\/3.*100%.*");
+        assertOutputMatches(".*relatid:.*3\\/3.*100%.*");
     }
 }

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FindingAidReportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FindingAidReportServiceTest.java
@@ -1,5 +1,6 @@
 package edu.unc.lib.boxc.migration.cdm.services;
 
+import edu.unc.lib.boxc.migration.cdm.AbstractOutputTest;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.options.FindingAidReportOptions;
 import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
@@ -8,6 +9,7 @@ import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -16,6 +18,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
@@ -24,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.MockitoAnnotations.openMocks;
 
-public class FindingAidReportServiceTest {
+public class FindingAidReportServiceTest extends AbstractOutputTest {
     private static final String PROJECT_NAME = "proj";
 
     @TempDir
@@ -35,7 +38,6 @@ public class FindingAidReportServiceTest {
     private SipServiceHelper testHelper;
 
     private AutoCloseable closeable;
-
 
     @BeforeEach
     public void setup() throws Exception {
@@ -52,6 +54,12 @@ public class FindingAidReportServiceTest {
         service = new FindingAidReportService();
         service.setProject(project);
         service.setIndexService(testHelper.getIndexService());
+        service.setFieldService(testHelper.getFieldService());
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test
@@ -103,6 +111,53 @@ public class FindingAidReportServiceTest {
             assertIterableEquals(Arrays.asList("03883_folder_5", "1"), rows.get(2));
             assertEquals(3, rows.size());
         }
+    }
+
+    @Test
+    public void assessCollectionReportWithFindingAidTest() throws Exception {
+        Files.copy(Paths.get("src/test/resources/roy_brown/cdm_fields.csv"), project.getFieldsPath());
+        CdmFieldService fieldService = new CdmFieldService();
+        FindingAidService findingAidService = new FindingAidService();
+        findingAidService.setCdmFieldService(fieldService);
+        findingAidService.setProject(project);
+        findingAidService.recordFindingAid();
+        testHelper.indexExportData("03883");
+
+        service.collectionReport();
+
+        assertOutputMatches(".*Hook id: +contri+.*");
+        assertOutputMatches(".*Collection number: +descri+.*");
+        assertOutputMatches(".*03883.*");
+        assertOutputMatches(".*Records with collection ids: +3 \\(100.0%\\).*");
+        assertOutputMatches(".*Records with hook ids: +3 \\(100.0%\\).*");
+        assertOutputMatches(".*collec:.*3\\/3.*100%.*");
+        assertOutputMatches(".*descri:.*3\\/3.*100%.*");
+        assertOutputMatches(".*findin:.*3\\/3.*100%.*");
+        assertOutputMatches(".*locati:.*3\\/3.*100%.*");
+        assertOutputMatches(".*title:.*3\\/3.*100%.*");
+        assertOutputMatches(".*prefer:.*3\\/3.*100%.*");
+        assertOutputMatches(".*creato:.*3\\/3.*100%.*");
+        assertOutputMatches(".*contri:.*3\\/3.*100%.*");
+        assertOutputMatches(".*relatid:.*3\\/3.*100%.*");
+    }
+
+    @Test
+    public void assessCollectionReportWithoutFindingAidTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+
+        service.collectionReport();
+
+        assertOutputMatches(".*Collection number is not set..*");
+        assertOutputMatches(".*Possible collection numbers:.*");
+        assertOutputMatches(".*collec:.*0\\/3.*100%.*");
+        assertOutputMatches(".*descri:.*3\\/3.*100%.*");
+        assertOutputMatches(".*findin:.*0\\/3.*100%.*");
+        assertOutputMatches(".*locati:.*0\\/3.*100%.*");
+        assertOutputMatches(".*title:.*3\\/3.*100%.*");
+        assertOutputMatches(".*prefer:.*0\\/3.*100%.*");
+        assertOutputMatches(".*creato:.*3\\/3.*100%.*");
+        assertOutputMatches(".*contri:.*2\\/3.*100%.*");
+        assertOutputMatches(".*relatid:.*0\\/3.*100%.*");
     }
 
     private CSVParser parser(Path csvPath) throws IOException {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FindingAidReportServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/FindingAidReportServiceTest.java
@@ -6,6 +6,7 @@ import edu.unc.lib.boxc.migration.cdm.options.FindingAidReportOptions;
 import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
 import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
+import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -19,6 +20,7 @@ import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 
@@ -115,13 +117,12 @@ public class FindingAidReportServiceTest extends AbstractOutputTest {
 
     @Test
     public void assessCollectionReportWithFindingAidTest() throws Exception {
-        Files.copy(Paths.get("src/test/resources/roy_brown/cdm_fields.csv"), project.getFieldsPath());
+        testHelper.indexExportData(Paths.get("src/test/resources/roy_brown/cdm_fields.csv"), "03883");
         CdmFieldService fieldService = new CdmFieldService();
         FindingAidService findingAidService = new FindingAidService();
         findingAidService.setCdmFieldService(fieldService);
         findingAidService.setProject(project);
         findingAidService.recordFindingAid();
-        testHelper.indexExportData("03883");
 
         service.collectionReport();
 
@@ -149,15 +150,15 @@ public class FindingAidReportServiceTest extends AbstractOutputTest {
 
         assertOutputMatches(".*Collection number is not set..*");
         assertOutputMatches(".*Possible collection numbers:.*");
-        assertOutputMatches(".*collec:.*0\\/3.*100%.*");
+        assertOutputMatches(".*collec:.*0\\/3.*0%.*");
         assertOutputMatches(".*descri:.*3\\/3.*100%.*");
-        assertOutputMatches(".*findin:.*0\\/3.*100%.*");
-        assertOutputMatches(".*locati:.*0\\/3.*100%.*");
+        assertOutputMatches(".*findin:.*0\\/3.*0%.*");
+        assertOutputMatches(".*locati:.*0\\/3.*0%.*");
         assertOutputMatches(".*title:.*3\\/3.*100%.*");
-        assertOutputMatches(".*prefer:.*0\\/3.*100%.*");
+        assertOutputMatches(".*prefer:.*0\\/3.*0%.*");
         assertOutputMatches(".*creato:.*3\\/3.*100%.*");
-        assertOutputMatches(".*contri:.*2\\/3.*100%.*");
-        assertOutputMatches(".*relatid:.*0\\/3.*100%.*");
+        assertOutputMatches(".*contri:.*2\\/3.*67%.*");
+        assertOutputMatches(".*relatid:.*0\\/3.*0%.*");
     }
 
     private CSVParser parser(Path csvPath) throws IOException {


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-3508](https://unclibrary.atlassian.net/browse/BXC-3508)

- add `-fa, --finding-aids` option to `generate_field_url_report` to generate a finding aids specific url report
- add `collection_report` command to `finding_aid_reports` to generate report to assess collection for associations with finding aids
- add `URL_QUERY` and `FINDING_AID_URL_QUERY` constants and `-finding-aids` option to `FieldUrlAssessmentService`
- add method `collectionReport` and helper methods `listCollectionIds`, `countRecords`, `listPotentialCollectionIds` to `FindingAidReportService`
- add and update tests