### PR TITLE
BXC-4945 workflow to import ref ids

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/AspaceRefIdCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/AspaceRefIdCommand.java
@@ -2,12 +2,10 @@ package edu.unc.lib.boxc.migration.cdm;
 
 import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
-import edu.unc.lib.boxc.migration.cdm.options.GroupMappingSyncOptions;
 import edu.unc.lib.boxc.migration.cdm.services.AspaceRefIdService;
 import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
 import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
 import org.slf4j.Logger;
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ParentCommand;
 
@@ -33,8 +31,8 @@ public class AspaceRefIdCommand {
     private AspaceRefIdService aspaceRefIdService;
 
     @Command(name="generate",
-            description = {"Generate the optional alt-text mapping file for this project.",
-                    "A blank alt_text_files.csv template will be created for this project, " +
+            description = {"Generate the optional aspace ref id mapping file for this project.",
+                    "A blank ref_id_mapping.csv template will be created for this project, " +
                             "with only cdm dmrecords populated."})
     public int generate() throws Exception {
         long start = System.nanoTime();

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/AspaceRefIdCommand.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/AspaceRefIdCommand.java
@@ -1,0 +1,90 @@
+package edu.unc.lib.boxc.migration.cdm;
+
+import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.options.GroupMappingSyncOptions;
+import edu.unc.lib.boxc.migration.cdm.services.AspaceRefIdService;
+import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
+import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import org.slf4j.Logger;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.ParentCommand;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static edu.unc.lib.boxc.migration.cdm.util.CLIConstants.outputLogger;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * @author krwong
+ */
+@Command(name = "aspace_ref_id",
+        description = "Commands related to aspace ref id mappings")
+public class AspaceRefIdCommand {
+    private static final Logger log = getLogger(AltTextCommand.class);
+
+    @ParentCommand
+    private CLIMain parentCommand;
+
+    private MigrationProject project;
+    private CdmIndexService indexService;
+    private AspaceRefIdService aspaceRefIdService;
+
+    @Command(name="generate",
+            description = {"Generate the optional alt-text mapping file for this project.",
+                    "A blank alt_text_files.csv template will be created for this project, " +
+                            "with only cdm dmrecords populated."})
+    public int generate() throws Exception {
+        long start = System.nanoTime();
+
+        try {
+            initialize();
+            aspaceRefIdService.generateAspaceRefIdMapping();
+            outputLogger.info("Aspace ref id mapping generated for {} in {}s", project.getProjectName(),
+                    (System.nanoTime() - start) / 1e9);
+            return 0;
+        } catch (MigrationException | IllegalArgumentException e) {
+            outputLogger.info("Cannot generate aspace ref id mapping: {}", e.getMessage());
+            return 1;
+        } catch (Exception e) {
+            log.error("Failed to generate aspace ref id template", e);
+            outputLogger.info("Failed to generate aspace ref id template: {}", e.getMessage(), e);
+            return 1;
+        }
+    }
+
+    @Command(name = "sync",
+            description = { "Sync the aspace ref id mapping file for this project into the index database." } )
+    public int sync() throws Exception {
+        long start = System.nanoTime();
+
+        try {
+            initialize();
+
+            aspaceRefIdService.syncMappings();
+            outputLogger.info("Aspace ref id mapping synced to index for {} in {}s", project.getProjectName(),
+                    (System.nanoTime() - start) / 1e9);
+            return 0;
+        } catch (MigrationException | IllegalArgumentException e) {
+            outputLogger.info("Cannot sync aspace ref id mappings: {}", e.getMessage());
+            log.warn("Cannot sync aspace ref id mapping", e);
+            return 1;
+        } catch (Exception e) {
+            log.error("Failed to sync aspace ref id mappings", e);
+            outputLogger.info("Failed to sync aspace ref id mappings: {}", e.getMessage(), e);
+            return 1;
+        }
+    }
+
+    private void initialize() throws IOException {
+        Path currentPath = parentCommand.getWorkingDirectory();
+        project = MigrationProjectFactory.loadMigrationProject(currentPath);
+        indexService = new CdmIndexService();
+        indexService.setProject(project);
+        aspaceRefIdService = new AspaceRefIdService();
+        aspaceRefIdService.setProject(project);
+        aspaceRefIdService.setIndexService(indexService);
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/CLIMain.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/CLIMain.java
@@ -47,7 +47,8 @@ import java.util.concurrent.Callable;
         ProcessSourceFilesCommand.class,
         AltTextCommand.class,
         BoxctronFileCommand.class,
-        FindingAidReportCommand.class
+        FindingAidReportCommand.class,
+        AspaceRefIdCommand.class
     })
 public class CLIMain implements Callable<Integer> {
     @Option(names = { "-w", "--work-dir" },

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/AspaceRefIdInfo.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/AspaceRefIdInfo.java
@@ -1,0 +1,63 @@
+package edu.unc.lib.boxc.migration.cdm.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Container class for accessing mappings of aspace ref ids to migration objects
+ * @author krwong
+ */
+public class AspaceRefIdInfo {
+    public static final String RECORD_ID_FIELD = CdmFieldInfo.CDM_ID;
+    public static final String REF_ID_FIELD = "aspaceRefId";
+    public static final String[] CSV_HEADERS = {RECORD_ID_FIELD, REF_ID_FIELD};
+
+    private List<AspaceRefIdMapping> mappings;
+
+    public AspaceRefIdInfo() {
+        mappings = new ArrayList<>();
+    }
+
+    /**
+     * @return Mappings of cdm objects to aspace ref ids
+     */
+    public List<AspaceRefIdMapping> getMappings() {
+        return mappings;
+    }
+
+    public void setMappings(List<AspaceRefIdMapping> mappings) {
+        this.mappings = mappings;
+    }
+
+    /**
+     * @param cdmId
+     * @return mapping with matching cdm id, or null if no match
+     */
+    public AspaceRefIdMapping getMappingByCdmId(String cdmId) {
+        return this.mappings.stream().filter(m -> m.getCdmId().equals(cdmId)).findFirst().orElse(null);
+    }
+
+    /**
+     * An individual mapping from a migration object to associated aspace ref id
+     */
+    public static class AspaceRefIdMapping {
+        private String cdmId;
+        private String aspaceRefId;
+
+        public String getCdmId() {
+            return cdmId;
+        }
+
+        public void setCdmId(String cdmId) {
+            this.cdmId = cdmId;
+        }
+
+        public String getAspaceRefId() {
+            return aspaceRefId;
+        }
+
+        public void setAspaceRefId(String aspaceRefId) {
+            this.aspaceRefId = aspaceRefId;
+        }
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProject.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProject.java
@@ -1,7 +1,5 @@
 package edu.unc.lib.boxc.migration.cdm.model;
 
-import edu.unc.lib.boxc.migration.cdm.jobs.VelocicroptorRemoteJob;
-
 import java.nio.file.Path;
 
 /**
@@ -32,6 +30,7 @@ public class MigrationProject {
     public static final String EXPORT_OBJECTS_FILENAME = "exported_objects.csv";
     public static final String ALT_TEXT_FILENAME = "alt_text.csv";
     public static final String ALT_TEXT_DIRNAME = "alt_text";
+    public static final String ASPACE_REF_ID_MAPPING_FILENAME = "ref_id_mapping.csv";
 
     private Path projectPath;
     private MigrationProjectProperties properties;
@@ -197,5 +196,12 @@ public class MigrationProject {
      */
     public Path getAltTextPath() {
         return projectPath.resolve(ALT_TEXT_DIRNAME);
+    }
+
+    /**
+     * @return Path of the aspace ref id mapping file
+     */
+    public Path getAspaceRefIdMappingPath() {
+        return projectPath.resolve(ASPACE_REF_ID_MAPPING_FILENAME);
     }
 }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProjectProperties.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/model/MigrationProjectProperties.java
@@ -20,6 +20,8 @@ public class MigrationProjectProperties {
     private Instant sourceFilesUpdatedDate;
     private Instant accessFilesUpdatedDate;
     private Instant altTextFilesUpdatedDate;
+    private Instant aspaceRefIdMappingsUpdatedDate;
+    private Instant aspaceRefIdMappingsSyncedDate;
     private Instant groupMappingsUpdatedDate;
     private Instant groupMappingsSyncedDate;
     private Instant descriptionsExpandedDate;
@@ -143,6 +145,28 @@ public class MigrationProjectProperties {
 
     public void setAltTextFilesUpdatedDate(Instant altTextFilesUpdatedDate) {
         this.altTextFilesUpdatedDate = altTextFilesUpdatedDate;
+    }
+
+    /**
+     * @return timestamp the aspace ref id mapping was last updated
+     */
+    public Instant getAspaceRefIdMappingsUpdatedDate() {
+        return aspaceRefIdMappingsUpdatedDate;
+    }
+
+    public void setAspaceRefIdMappingsUpdatedDate(Instant aspaceRefIdMappingsUpdatedDate) {
+        this.aspaceRefIdMappingsUpdatedDate = aspaceRefIdMappingsUpdatedDate;
+    }
+
+    /**
+     * @return timestamp the aspace ref id mapping was last synced to the database
+     */
+    public Instant getAspaceRefIdMappingsSyncedDate() {
+        return aspaceRefIdMappingsSyncedDate;
+    }
+
+    public void setAspaceRefIdMappingsSyncedDate(Instant aspaceRefIdMappingsSyncedDate) {
+        this.aspaceRefIdMappingsSyncedDate = aspaceRefIdMappingsSyncedDate;
     }
 
     /**

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdService.java
@@ -1,0 +1,218 @@
+package edu.unc.lib.boxc.migration.cdm.services;
+
+import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
+import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
+import edu.unc.lib.boxc.migration.cdm.model.AspaceRefIdInfo;
+import edu.unc.lib.boxc.migration.cdm.model.CdmFieldInfo;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.csv.CSVRecord;
+import org.slf4j.Logger;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Aspace ref id service
+ * @author krwong
+ */
+public class AspaceRefIdService {
+    private static final Logger log = getLogger(AspaceRefIdService.class);
+
+    private MigrationProject project;
+    private CdmIndexService indexService;
+    private List<String> ids;
+
+    public AspaceRefIdService() {
+    }
+
+    /**
+     * Generate the aspace ref id mapping template
+     * @throws Exception
+     */
+    public void generateAspaceRefIdMapping() throws IOException {
+        assertProjectStateValid();
+        Path mappingPath = getMappingPath();
+        BufferedWriter writer = Files.newBufferedWriter(mappingPath);
+
+        try (var csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT
+                .withHeader(AspaceRefIdInfo.CSV_HEADERS))) {
+            for (var id : getIds()) {
+                csvPrinter.printRecord(id, null);
+            }
+        }
+
+        setUpdatedDate(Instant.now());
+    }
+
+    /**
+     * Syncs aspace ref id mappings from the mapping file into the database. Clears out any previously synced
+     * aspace ref id mapping details before updating.
+     * @throws IOException
+     */
+    public void syncMappings() throws IOException {
+        assertProjectStateValid();
+        if (project.getProjectProperties().getAspaceRefIdMappingsUpdatedDate() == null
+                || Files.notExists(project.getAspaceRefIdMappingPath())) {
+            throw new InvalidProjectStateException("Project has not previously generated aspace ref id mappings");
+        }
+
+        Connection conn = null;
+        try {
+            conn = indexService.openDbConnection();
+            Statement stmt = conn.createStatement();
+            // Cleanup any previously synced grouping data
+            cleanupStaleSyncedRefIds(stmt);
+            if (project.getProjectProperties().getAspaceRefIdMappingsSyncedDate() != null) {
+                setSyncedDate(null);
+            }
+
+            // Sync the aspace ref ids into the database
+            AspaceRefIdInfo info = loadMappings();
+            for (AspaceRefIdInfo.AspaceRefIdMapping entry : info.getMappings()) {
+                String cdmId = entry.getCdmId();
+                String aspaceRefId = entry.getAspaceRefId();
+
+                updateAspaceRefIdEntry(stmt, cdmId, aspaceRefId);
+            }
+        } catch (SQLException e) {
+            throw new MigrationException("Error interacting with export index", e);
+        } finally {
+            CdmIndexService.closeDbConnection(conn);
+        }
+        setSyncedDate(Instant.now());
+    }
+
+    private void cleanupStaleSyncedRefIds(Statement stmt) throws SQLException {
+        // Clear out of date aspace ref ids
+        stmt.executeUpdate("update " + CdmIndexService.TB_NAME
+                + " set " + CdmIndexService.ASPACE_REF_ID + " = null ");
+    }
+
+    private void updateAspaceRefIdEntry(Statement stmt, String aspaceRefId, String cdmId) throws SQLException {
+        stmt.executeUpdate("update " + CdmIndexService.TB_NAME
+                + " set " + CdmIndexService.ASPACE_REF_ID + " = '" + aspaceRefId + "'"
+                + " where " + CdmFieldInfo.CDM_ID + " = '"  + cdmId + "'");
+    }
+
+    protected void setUpdatedDate(Instant timestamp) throws IOException {
+        project.getProjectProperties().setAspaceRefIdMappingsUpdatedDate(timestamp);
+        ProjectPropertiesSerialization.write(project);
+    }
+
+    private void setSyncedDate(Instant timestamp) throws IOException {
+        project.getProjectProperties().setAspaceRefIdMappingsSyncedDate(timestamp);
+        ProjectPropertiesSerialization.write(project);
+    }
+
+    public Path getMappingPath() {
+        return project.getAspaceRefIdMappingPath();
+    }
+
+    private List<String> getIds() {
+        if (ids == null) {
+            ids = new ArrayList<>();
+            // for all work objects in the project (grouped works, compound objects, and single file works)
+            String query = "select " + CdmFieldInfo.CDM_ID
+                    + " from " + CdmIndexService.TB_NAME
+                    + " where " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_GROUPED_WORK + "'"
+                    + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_COMPOUND_OBJECT + "'"
+                    + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " = '" + CdmIndexService.ENTRY_TYPE_DOCUMENT_PDF + "'"
+                    + " or " + CdmIndexService.ENTRY_TYPE_FIELD + " is null"
+                    + " and " + CdmIndexService.PARENT_ID_FIELD + " is null";
+
+            getIndexService();
+            try (Connection conn = indexService.openDbConnection()) {
+                var stmt = conn.createStatement();
+                var rs = stmt.executeQuery(query);
+                while (rs.next()) {
+                    if (!rs.getString(1).isEmpty()) {
+                        ids.add(rs.getString(1));
+                    }
+                }
+                return ids;
+            } catch (SQLException e) {
+                throw new MigrationException("Error interacting with export index", e);
+            }
+        }
+        return ids;
+    }
+
+    /**
+     * @return the aspace ref id mapping info for the configured project
+     * @throws IOException
+     */
+    public AspaceRefIdInfo loadMappings() throws IOException {
+        return loadMappings(getMappingPath());
+    }
+
+    public static AspaceRefIdInfo loadMappings(Path mappingPath) throws IOException {
+        AspaceRefIdInfo info = new AspaceRefIdInfo();
+        if (Files.notExists(mappingPath)) {
+            return info;
+        }
+        try (var csvParser = openMappingsParser(mappingPath)) {
+            List<AspaceRefIdInfo.AspaceRefIdMapping> mappings = info.getMappings();
+            for(CSVRecord csvRecord : csvParser) {
+                mappings.add(recordToMapping(csvRecord));
+            }
+            return info;
+        }
+    }
+
+    public static AspaceRefIdInfo.AspaceRefIdMapping recordToMapping(CSVRecord csvRecord) {
+        AspaceRefIdInfo.AspaceRefIdMapping mapping = new AspaceRefIdInfo.AspaceRefIdMapping();
+        mapping.setCdmId(csvRecord.get(0));
+        mapping.setAspaceRefId(csvRecord.get(1));
+        return mapping;
+    }
+
+    /**
+     * @param mappingsPath Path of the CSV to read from
+     * @return CSVParser for reading from the csv file
+     * @throws IOException
+     */
+    public static CSVParser openMappingsParser(Path mappingsPath) throws IOException {
+        Reader reader = Files.newBufferedReader(mappingsPath);
+        return new CSVParser(reader, CSVFormat.DEFAULT
+                .withFirstRecordAsHeader()
+                .withHeader(AspaceRefIdInfo.CSV_HEADERS)
+                .withTrim());
+    }
+
+    private CdmIndexService getIndexService() {
+        if (indexService == null) {
+            indexService = new CdmIndexService();
+            indexService.setProject(project);
+        }
+        return indexService;
+    }
+
+    protected void assertProjectStateValid() {
+        if (project.getProjectProperties().getIndexedDate() == null) {
+            throw new InvalidProjectStateException("Project must be indexed prior to generating source mappings");
+        }
+    }
+
+    public void setProject(MigrationProject project) {
+        this.project = project;
+    }
+
+    public void setIndexService(CdmIndexService indexService) {
+        this.indexService = indexService;
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/CdmIndexService.java
@@ -16,14 +16,9 @@ import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
-import org.jdom2.output.Format;
-import org.jdom2.output.XMLOutputter;
 import org.slf4j.Logger;
 
-import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.file.Files;
@@ -61,8 +56,9 @@ public class CdmIndexService {
     public static final String ENTRY_TYPE_COMPOUND_OBJECT = "cpd_object";
     public static final String ENTRY_TYPE_COMPOUND_CHILD = "cpd_child";
     public static final String ENTRY_TYPE_DOCUMENT_PDF = "doc_pdf";
+    public static final String ASPACE_REF_ID = "aspace_ref_id";
     public static final List<String> MIGRATION_FIELDS = Arrays.asList(
-            PARENT_ID_FIELD, ENTRY_TYPE_FIELD, CHILD_ORDER_FIELD);
+            PARENT_ID_FIELD, ENTRY_TYPE_FIELD, CHILD_ORDER_FIELD, ASPACE_REF_ID);
     private static final Pattern CONTROL_PATTERN = Pattern.compile("[\\p{Cntrl}&&[^\r\n\t]]");
     private static final Pattern IGNORE_CLOSING_PATTERN = Pattern.compile(
             "(a|span|div|img|ul|li|ol|h\\d|input|label|html|table|tr|td|th)");

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/SipService.java
@@ -64,6 +64,7 @@ public class SipService {
     private SourceFileService sourceFileService;
     private AccessFileService accessFileService;
     private AltTextService altTextService;
+    private AspaceRefIdService aspaceRefIdService;
     private DescriptionsService descriptionsService;
     private RedirectMappingService redirectMappingService;
     private PremisLoggerFactory premisLoggerFactory;
@@ -105,6 +106,7 @@ public class SipService {
         workGeneratorFactory.setDescriptionsService(descriptionsService);
         workGeneratorFactory.setAccessFileService(accessFileService);
         workGeneratorFactory.setAltTextService(altTextService);
+        workGeneratorFactory.setAspaceRefIdService(aspaceRefIdService);
         workGeneratorFactory.setRedirectMappingService(redirectMappingService);
         workGeneratorFactory.setPidMinter(pidMinter);
         workGeneratorFactory.setPostMigrationReportService(postMigrationReportService);
@@ -125,6 +127,11 @@ public class SipService {
             workGeneratorFactory.setAltTextInfo(altTextService.loadMappings());
         } catch (NoSuchFileException e) {
             log.debug("No alt text mappings file, no alt text files will be added to the SIP");
+        }
+        try {
+            workGeneratorFactory.setAspaceRefIdInfo(aspaceRefIdService.loadMappings());
+        } catch (NoSuchFileException e) {
+            log.debug("No aspace ref id mappings file, no aspace ref ids will be added to the SIP");
         }
         workGeneratorFactory.setConn(conn);
         initializeDestinations(options);
@@ -416,6 +423,10 @@ public class SipService {
 
     public void setAltTextService(AltTextService altTextService) {
         this.altTextService = altTextService;
+    }
+
+    public void setAspaceRefIdService(AspaceRefIdService aspaceRefIdService) {
+        this.aspaceRefIdService = aspaceRefIdService;
     }
 
     public void setDescriptionsService(DescriptionsService descriptionsService) {

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGenerator.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGenerator.java
@@ -4,6 +4,7 @@ import edu.unc.lib.boxc.auth.api.UserRole;
 import edu.unc.lib.boxc.deposit.impl.model.DepositModelHelpers;
 import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
 import edu.unc.lib.boxc.migration.cdm.model.AltTextInfo;
+import edu.unc.lib.boxc.migration.cdm.model.AspaceRefIdInfo;
 import edu.unc.lib.boxc.migration.cdm.model.DestinationSipEntry;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.model.PermissionsInfo;
@@ -11,6 +12,7 @@ import edu.unc.lib.boxc.migration.cdm.model.SourceFilesInfo;
 import edu.unc.lib.boxc.migration.cdm.options.SipGenerationOptions;
 import edu.unc.lib.boxc.migration.cdm.services.AccessFileService;
 import edu.unc.lib.boxc.migration.cdm.services.AltTextService;
+import edu.unc.lib.boxc.migration.cdm.services.AspaceRefIdService;
 import edu.unc.lib.boxc.migration.cdm.services.DescriptionsService;
 import edu.unc.lib.boxc.migration.cdm.services.PostMigrationReportService;
 import edu.unc.lib.boxc.migration.cdm.services.RedirectMappingService;
@@ -20,6 +22,7 @@ import edu.unc.lib.boxc.model.api.DatastreamType;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.ids.PIDMinter;
 import edu.unc.lib.boxc.model.api.rdf.Cdr;
+import edu.unc.lib.boxc.model.api.rdf.CdrAspace;
 import edu.unc.lib.boxc.model.api.rdf.CdrDeposit;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -62,6 +65,7 @@ public class WorkGenerator {
     protected SourceFilesInfo sourceFilesInfo;
     protected SourceFilesInfo accessFilesInfo;
     protected AltTextInfo altTextInfo;
+    protected AspaceRefIdInfo aspaceRefIdInfo;
     protected Connection conn;
     protected SipGenerationOptions options;
     protected Model model;
@@ -70,6 +74,7 @@ public class WorkGenerator {
     protected DescriptionsService descriptionsService;
     protected AccessFileService accessFileService;
     protected AltTextService altTextService;
+    protected AspaceRefIdService aspaceRefIdService;
     protected PostMigrationReportService postMigrationReportService;
     protected PermissionsInfo permissionsInfo;
     protected StreamingMetadataService streamingMetadataService;
@@ -110,6 +115,7 @@ public class WorkGenerator {
 
         // add permission to work
         addPermission(cdmId, workBag);
+        addRefId(cdmId, workBag);
 
         // Copy description to SIP
         copyDescriptionToSip(workPid, expDescPath);
@@ -280,6 +286,16 @@ public class WorkGenerator {
             if (altTextMapping != null && !StringUtils.isBlank(altTextMapping.getAltTextBody())) {
                 Path sipAltTextPath = destEntry.getDepositDirManager().getAltTextPath(pid, true);
                 altTextService.writeAltTextToFile(cdmId, sipAltTextPath);
+            }
+        }
+    }
+
+    protected void addRefId(String cdmId, Resource resource) {
+        if (aspaceRefIdInfo != null) {
+            AspaceRefIdInfo.AspaceRefIdMapping aspaceRefIdMapping = aspaceRefIdInfo.getMappingByCdmId(cdmId);
+            if (aspaceRefIdMapping != null && !StringUtils.isBlank(aspaceRefIdMapping.getAspaceRefId())) {
+                String refId = aspaceRefIdMapping.getAspaceRefId();
+                resource.addProperty(CdrAspace.refId, refId);
             }
         }
     }

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGeneratorFactory.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/services/sips/WorkGeneratorFactory.java
@@ -1,6 +1,7 @@
 package edu.unc.lib.boxc.migration.cdm.services.sips;
 
 import edu.unc.lib.boxc.migration.cdm.model.AltTextInfo;
+import edu.unc.lib.boxc.migration.cdm.model.AspaceRefIdInfo;
 import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
 import edu.unc.lib.boxc.migration.cdm.model.PermissionsInfo;
 import edu.unc.lib.boxc.migration.cdm.model.SourceFilesInfo;
@@ -8,6 +9,7 @@ import edu.unc.lib.boxc.migration.cdm.options.SipGenerationOptions;
 import edu.unc.lib.boxc.migration.cdm.services.AccessFileService;
 import edu.unc.lib.boxc.migration.cdm.services.AggregateFileMappingService;
 import edu.unc.lib.boxc.migration.cdm.services.AltTextService;
+import edu.unc.lib.boxc.migration.cdm.services.AspaceRefIdService;
 import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
 import edu.unc.lib.boxc.migration.cdm.services.DescriptionsService;
 import edu.unc.lib.boxc.migration.cdm.services.PostMigrationReportService;
@@ -29,6 +31,8 @@ public class WorkGeneratorFactory {
     private AccessFileService accessFileService;
     private AltTextInfo altTextInfo;
     private AltTextService altTextService;
+    private AspaceRefIdInfo aspaceRefIdInfo;
+    private AspaceRefIdService aspaceRefIdService;
     private Connection conn;
     private SipGenerationOptions options;
     private CdmToDestMapper cdmToDestMapper;
@@ -57,6 +61,8 @@ public class WorkGeneratorFactory {
         gen.sourceFilesInfo = sourceFilesInfo;
         gen.altTextInfo = altTextInfo;
         gen.altTextService = altTextService;
+        gen.aspaceRefIdInfo = aspaceRefIdInfo;
+        gen.aspaceRefIdService = aspaceRefIdService;
         gen.descriptionsService = descriptionsService;
         gen.conn = conn;
         gen.options = options;
@@ -85,6 +91,10 @@ public class WorkGeneratorFactory {
         this.altTextInfo = altTextInfo;
     }
 
+    public void setAspaceRefIdInfo(AspaceRefIdInfo aspaceRefIdInfo) {
+        this.aspaceRefIdInfo = aspaceRefIdInfo;
+    }
+
     public void setConn(Connection conn) {
         this.conn = conn;
     }
@@ -107,6 +117,10 @@ public class WorkGeneratorFactory {
 
     public void setAltTextService(AltTextService altTextService) {
         this.altTextService = altTextService;
+    }
+
+    public void setAspaceRefIdService(AspaceRefIdService aspaceRefIdService) {
+        this.aspaceRefIdService = aspaceRefIdService;
     }
 
     public void setDescriptionsService(DescriptionsService descriptionsService) {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/AspaceRefIdCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/AspaceRefIdCommandIT.java
@@ -1,0 +1,136 @@
+package edu.unc.lib.boxc.migration.cdm;
+
+import edu.unc.lib.boxc.migration.cdm.model.AspaceRefIdInfo;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
+import edu.unc.lib.boxc.migration.cdm.services.CdmIndexService;
+import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AspaceRefIdCommandIT extends AbstractCommandIT {
+    private Path basePath;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        initProjectAndHelper();
+        basePath = tmpFolder;
+    }
+
+    @Test
+    public void generateNotIndexedTest() throws Exception {
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "aspace_ref_id", "generate"};
+        executeExpectFailure(args);
+
+        assertOutputContains("Project must be indexed");
+
+        assertUpdatedDateNotPresent();
+    }
+
+    @Test
+    public void generateAspaceRefIdMappingSucceedsTest() throws Exception {
+        indexExportSamples();
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "aspace_ref_id", "generate"};
+        executeExpectSuccess(args);
+
+        assertTrue(Files.exists(project.getAspaceRefIdMappingPath()));
+
+        assertUpdatedDatePresent();
+    }
+
+    @Test
+    public void generateAndSyncAspaceRefITest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "aspace_ref_id", "generate"};
+        executeExpectSuccess(args);
+
+        assertTrue(Files.exists(project.getAspaceRefIdMappingPath()));
+        assertUpdatedDatePresent();
+
+        writeCsv(mappingBody("25,2817ec3c77e5ea9846d5c070d58d402b", "26,3817ec3c77e5ea9846d5c070d58d402b",
+                "27,4817ec3c77e5ea9846d5c070d58d402b"));
+
+        String[] args2 = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "aspace_ref_id", "sync" };
+        executeExpectSuccess(args2);
+
+        var indexService = new CdmIndexService();
+        indexService.setProject(project);
+        Connection conn = null;
+        try {
+            conn = indexService.openDbConnection();
+            assertWorkSynced(conn, "25", "2817ec3c77e5ea9846d5c070d58d402b");
+            assertWorkSynced(conn, "26", "3817ec3c77e5ea9846d5c070d58d402b");
+            assertWorkSynced(conn, "27", "4817ec3c77e5ea9846d5c070d58d402b");
+            assertSyncedDatePresent();
+        } finally {
+            CdmIndexService.closeDbConnection(conn);
+        }
+    }
+
+    private void indexExportSamples() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+    }
+
+    private void assertWorkSynced(Connection conn, String expectedCdmId, String expectedAspaceRefId)
+            throws Exception {
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("select * from " + CdmIndexService.TB_NAME
+                + " where " + CdmIndexService.ASPACE_REF_ID + " is not null ");
+        while (rs.next()) {
+            String cdmId = rs.getString(AspaceRefIdInfo.RECORD_ID_FIELD);
+            String refId = rs.getString(AspaceRefIdInfo.REF_ID_FIELD);
+            assertEquals(expectedCdmId, cdmId);
+            assertEquals(expectedAspaceRefId, refId);
+        }
+    }
+
+    private void assertUpdatedDatePresent() throws Exception {
+        MigrationProjectProperties props = ProjectPropertiesSerialization.read(project.getProjectPropertiesPath());
+        assertNotNull(props.getAspaceRefIdMappingsUpdatedDate(), "Updated timestamp must be set");
+    }
+
+    private void assertUpdatedDateNotPresent() throws Exception {
+        MigrationProjectProperties props = ProjectPropertiesSerialization.read(project.getProjectPropertiesPath());
+        assertNull(props.getAspaceRefIdMappingsUpdatedDate(), "Updated timestamp must not be set");
+    }
+
+    private void assertSyncedDatePresent() throws Exception {
+        MigrationProjectProperties props = ProjectPropertiesSerialization.read(project.getProjectPropertiesPath());
+        assertNotNull(props.getAspaceRefIdMappingsSyncedDate());
+    }
+
+    private String mappingBody(String... rows) {
+        return String.join(",", AspaceRefIdInfo.CSV_HEADERS) + "\n"
+                + String.join("\n", rows);
+    }
+
+    private void writeCsv(String mappingBody) throws IOException {
+        FileUtils.write(project.getAspaceRefIdMappingPath().toFile(),
+                mappingBody, StandardCharsets.UTF_8);
+        project.getProjectProperties().setAspaceRefIdMappingsUpdatedDate(Instant.now());
+        ProjectPropertiesSerialization.write(project);
+    }
+}

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdServiceTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/services/AspaceRefIdServiceTest.java
@@ -1,0 +1,284 @@
+package edu.unc.lib.boxc.migration.cdm.services;
+
+import edu.unc.lib.boxc.migration.cdm.exceptions.InvalidProjectStateException;
+import edu.unc.lib.boxc.migration.cdm.model.AspaceRefIdInfo;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProjectProperties;
+import edu.unc.lib.boxc.migration.cdm.options.GroupMappingOptions;
+import edu.unc.lib.boxc.migration.cdm.options.GroupMappingSyncOptions;
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
+import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
+import edu.unc.lib.boxc.migration.cdm.util.ProjectPropertiesSerialization;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+public class AspaceRefIdServiceTest {
+    private static final String PROJECT_NAME = "proj";
+
+    @TempDir
+    public Path tmpFolder;
+    private Path basePath;
+    private MigrationProject project;
+    private SipServiceHelper testHelper;
+    private CdmIndexService indexService;
+    private AspaceRefIdService service;
+
+    private AutoCloseable closeable;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        closeable = openMocks(this);
+        project = MigrationProjectFactory.createMigrationProject(
+                tmpFolder, PROJECT_NAME, null, "user", CdmEnvironmentHelper.DEFAULT_ENV_ID,
+                BxcEnvironmentHelper.DEFAULT_ENV_ID, MigrationProject.PROJECT_SOURCE_CDM);
+        Files.createDirectories(project.getExportPath());
+
+        basePath = tmpFolder.resolve("testFolder");
+        Files.createDirectory(basePath);
+        testHelper = new SipServiceHelper(project, basePath);
+        indexService = testHelper.getIndexService();
+        service = testHelper.getAspaceRefIdService();
+        service.setProject(project);
+        service.setIndexService(testHelper.getIndexService());
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
+    }
+
+    @Test
+    public void generateWorkObjectsTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        service.generateAspaceRefIdMapping();
+
+        assertTrue(Files.exists(project.getAspaceRefIdMappingPath()));
+
+        try (CSVParser csvParser = parser()) {
+            List<CSVRecord> rows = csvParser.getRecords();
+            assertEquals("25", rows.get(0).get(AspaceRefIdInfo.RECORD_ID_FIELD));
+            assertEquals("26", rows.get(1).get(AspaceRefIdInfo.RECORD_ID_FIELD));
+            assertEquals("27", rows.get(2).get(AspaceRefIdInfo.RECORD_ID_FIELD));
+            assertEquals(3, rows.size());
+        }
+    }
+
+    @Test
+    public void generateGroupObjectsTest() throws Exception {
+        testHelper.indexExportData("grouped_gilmer");
+        setupGroupIndex();
+
+        service.generateAspaceRefIdMapping();
+
+        assertTrue(Files.exists(project.getAspaceRefIdMappingPath()));
+
+        try (CSVParser csvParser = parser()) {
+            List<CSVRecord> rows = csvParser.getRecords();
+            assertEquals("27", rows.get(0).get(AspaceRefIdInfo.RECORD_ID_FIELD));
+            assertEquals("28", rows.get(1).get(AspaceRefIdInfo.RECORD_ID_FIELD));
+            assertEquals("29", rows.get(2).get(AspaceRefIdInfo.RECORD_ID_FIELD));
+            assertEquals("grp:groupa:group1", rows.get(3).get(AspaceRefIdInfo.RECORD_ID_FIELD));
+            assertEquals(4, rows.size());
+        }
+    }
+
+    @Test
+    public void generateCompoundObjectsTest() throws Exception {
+        testHelper.indexExportData("mini_keepsakes");
+        service.generateAspaceRefIdMapping();
+
+        assertTrue(Files.exists(project.getAspaceRefIdMappingPath()));
+
+        try (CSVParser csvParser = parser()) {
+            List<CSVRecord> rows = csvParser.getRecords();
+            assertEquals("216", rows.get(0).get(AspaceRefIdInfo.RECORD_ID_FIELD));
+            assertEquals("604", rows.get(1).get(AspaceRefIdInfo.RECORD_ID_FIELD));
+            assertEquals("607", rows.get(2).get(AspaceRefIdInfo.RECORD_ID_FIELD));
+            assertEquals(3, rows.size());
+        }
+    }
+
+    @Test
+    public void generatePdfCompoundObjectsTest() throws Exception {
+        testHelper.indexExportData("pdf");
+        service.generateAspaceRefIdMapping();
+
+        assertTrue(Files.exists(project.getAspaceRefIdMappingPath()));
+
+        try (CSVParser csvParser = parser()) {
+            List<CSVRecord> rows = csvParser.getRecords();
+            assertEquals("17940", rows.get(0).get(AspaceRefIdInfo.RECORD_ID_FIELD));
+            assertEquals(1, rows.size());
+        }
+    }
+
+    @Test
+    public void syncNotIndexedTest() throws Exception {
+        var e = assertThrows(InvalidProjectStateException.class, () -> {
+            service.syncMappings();
+        });
+        assertExceptionContains("Project must be indexed", e);
+        assertMappedDateNotPresent();
+        assertSyncedDateNotPresent();
+    }
+
+    @Test
+    public void syncNotGeneratedTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        var e = assertThrows(InvalidProjectStateException.class, () -> {
+            service.syncMappings();
+        });
+        assertExceptionContains("Project has not previously generated aspace ref id mappings", e);
+        assertMappedDateNotPresent();
+        assertSyncedDateNotPresent();
+    }
+
+    @Test
+    public void syncSingleRunTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        writeCsv(mappingBody("25,2817ec3c77e5ea9846d5c070d58d402b", "26,3817ec3c77e5ea9846d5c070d58d402b",
+                "27,4817ec3c77e5ea9846d5c070d58d402b"));
+
+        service.syncMappings();
+
+        Connection conn = null;
+        try {
+            conn = indexService.openDbConnection();
+            assertWorkSynced(conn, "25", "2817ec3c77e5ea9846d5c070d58d402b");
+            assertWorkSynced(conn, "26", "3817ec3c77e5ea9846d5c070d58d402b");
+            assertWorkSynced(conn, "27", "4817ec3c77e5ea9846d5c070d58d402b");
+            assertSyncedDatePresent();
+        } finally {
+            CdmIndexService.closeDbConnection(conn);
+        }
+    }
+
+    @Test
+    public void syncSecondRunWithCleanupTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        writeCsv(mappingBody("25,2817ec3c77e5ea9846d5c070d58d402b", "26,3817ec3c77e5ea9846d5c070d58d402b",
+                "27,4817ec3c77e5ea9846d5c070d58d402b"));
+
+        service.syncMappings();
+
+        Connection conn = null;
+        try {
+            conn = indexService.openDbConnection();
+            assertWorkSynced(conn, "25", "2817ec3c77e5ea9846d5c070d58d402b");
+            assertWorkSynced(conn, "26", "3817ec3c77e5ea9846d5c070d58d402b");
+            assertWorkSynced(conn, "27", "4817ec3c77e5ea9846d5c070d58d402b");
+
+            assertSyncedDatePresent();
+        } finally {
+            CdmIndexService.closeDbConnection(conn);
+        }
+
+        writeCsv(mappingBody("25,2817ec3c77e5ea9846d5c070d58d402b", "26,3817ec3c77e5ea9846d5c070d58d402b"));
+
+        service.syncMappings();
+
+        try {
+            conn = indexService.openDbConnection();
+            assertWorkSynced(conn, "25", "2817ec3c77e5ea9846d5c070d58d402b");
+            assertWorkSynced(conn, "26", "3817ec3c77e5ea9846d5c070d58d402b");
+            assertWorkSynced(conn, "27", "4817ec3c77e5ea9846d5c070d58d402b");
+            assertSyncedDatePresent();
+        } finally {
+            CdmIndexService.closeDbConnection(conn);
+        }
+    }
+
+    private CSVParser parser() throws IOException {
+        Reader reader = Files.newBufferedReader(project.getAspaceRefIdMappingPath());
+        CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
+                .withFirstRecordAsHeader()
+                .withHeader(AspaceRefIdInfo.CSV_HEADERS)
+                .withTrim());
+        return csvParser;
+    }
+
+    private String mappingBody(String... rows) {
+        return String.join(",", AspaceRefIdInfo.CSV_HEADERS) + "\n"
+                + String.join("\n", rows);
+    }
+
+    private void writeCsv(String mappingBody) throws IOException {
+        FileUtils.write(project.getAspaceRefIdMappingPath().toFile(),
+                mappingBody, StandardCharsets.UTF_8);
+        project.getProjectProperties().setAspaceRefIdMappingsUpdatedDate(Instant.now());
+        ProjectPropertiesSerialization.write(project);
+    }
+
+    private GroupMappingSyncOptions makeDefaultSyncOptions() {
+        var options = new GroupMappingSyncOptions();
+        options.setSortField("file");
+        return options;
+    }
+
+    private void setupGroupIndex() throws Exception {
+        GroupMappingOptions groupOptions = new GroupMappingOptions();
+        groupOptions.setGroupFields(Arrays.asList("groupa"));
+        GroupMappingService groupService = testHelper.getGroupMappingService();
+        groupService.generateMapping(groupOptions);
+        groupService.syncMappings(makeDefaultSyncOptions());
+    }
+
+    private void assertWorkSynced(Connection conn, String expectedCdmId, String expectedAspaceRefId)
+            throws Exception {
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("select * from " + CdmIndexService.TB_NAME
+                + " where " + CdmIndexService.ASPACE_REF_ID + " is not null ");
+        while (rs.next()) {
+            String cdmId = rs.getString(AspaceRefIdInfo.RECORD_ID_FIELD);
+            String refId = rs.getString(AspaceRefIdInfo.REF_ID_FIELD);
+            assertEquals(expectedCdmId, cdmId);
+            assertEquals(expectedAspaceRefId, refId);
+        }
+    }
+
+    private void assertExceptionContains(String expected, Exception e) {
+        assertTrue(e.getMessage().contains(expected),
+                "Expected message exception to contain '" + expected + "', but was: " + e.getMessage());
+    }
+
+    private void assertMappedDateNotPresent() throws Exception {
+        MigrationProjectProperties props = ProjectPropertiesSerialization.read(project.getProjectPropertiesPath());
+        assertNull(props.getAspaceRefIdMappingsUpdatedDate());
+    }
+
+    private void assertSyncedDatePresent() throws Exception {
+        MigrationProjectProperties props = ProjectPropertiesSerialization.read(project.getProjectPropertiesPath());
+        assertNotNull(props.getAspaceRefIdMappingsSyncedDate());
+    }
+
+    private void assertSyncedDateNotPresent() throws Exception {
+        MigrationProjectProperties props = ProjectPropertiesSerialization.read(project.getProjectPropertiesPath());
+        assertNull(props.getAspaceRefIdMappingsUpdatedDate());
+    }
+}


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4945](https://unclibrary.atlassian.net/browse/BXC-4945)

- add `AspaceRefIdService` and `AspaceRefIdInfo`
- add `ASPACE_REF_ID_MAPPING_FILENAME` to `MigrationProject`, `aspaceRefIdMappingsUpdatedDate` and `aspaceRefIdMappingsSyncedDate` to `MigrationProjectProperties`, and `ASPACE_REF_ID` column to index, 
- `aspace_ref_id generate` command to generate `ref_id_mapping.csv` template with work ids populated and an empty aspace ref id column
- `aspace_ref_id sync` command to import `ref_id_mapping.csv` into the index
- update SIP generation to add aspace ref ids to works if said ref ids are populated in the database
- add tests