### PR TITLE
BXC-4955 validate aspace ref ids

### DIFF
--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/validators/AspaceRefIdValidator.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/validators/AspaceRefIdValidator.java
@@ -1,0 +1,95 @@
+package edu.unc.lib.boxc.migration.cdm.validators;
+
+import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
+import edu.unc.lib.boxc.migration.cdm.model.AspaceRefIdInfo;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class AspaceRefIdValidator {
+    private static final Logger log = getLogger(AspaceRefIdValidator.class);
+    private MigrationProject project;
+    protected Set<String> previousIds = new HashSet<>();
+    protected List<String> errors = new ArrayList<>();
+
+    public static final String REF_ID_QUERY = "[a-zA-Z0-9]{32}";
+
+    public List<String> validateMappings(boolean force) {
+        try (
+                Reader reader = Files.newBufferedReader(getMappingPath());
+                CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
+                        .withFirstRecordAsHeader()
+                        .withHeader(AspaceRefIdInfo.CSV_HEADERS)
+                        .withTrim());
+        ) {
+            int i = 2;
+            for (CSVRecord csvRecord : csvParser) {
+                if (csvRecord.size() != 2) {
+                    errors.add("Invalid entry at line " + i + ", must be 2 columns but were " + csvRecord.size());
+                    continue;
+                }
+                String id = csvRecord.get(0);
+                String refId = csvRecord.get(1);
+
+                if (StringUtils.isBlank(id)) {
+                    if (!force) {
+                        errors.add("Invalid blank id at line " + i);
+                    }
+                } else {
+                    if (previousIds.contains(id)) {
+                        errors.add("Duplicate mapping for id " + id + " at line " + i);
+                    }
+                    previousIds.add(id);
+                }
+
+                if (refId == null || refId.isEmpty()) {
+                    if (!force && !allowUnmapped()) {
+                        errors.add("No aspace ref id mapped at line " + i);
+                    }
+                } else {
+                    Pattern pattern = Pattern.compile(REF_ID_QUERY);
+                    Matcher matcher = pattern.matcher(refId);
+                    if (!matcher.matches()) {
+                        errors.add("Invalid ref id at line " + i);
+                    }
+                }
+
+                i++;
+            }
+            if (i == 2) {
+                errors.add("Mappings file contained no mappings");
+            }
+        } catch (IOException e) {
+            throw new MigrationException("Failed to read mappings file", e);
+        }
+        return errors;
+    }
+
+    protected Path getMappingPath() {
+        return project.getAspaceRefIdMappingPath();
+    }
+
+    protected boolean allowUnmapped() {
+        return false;
+    }
+
+    public void setProject(MigrationProject project) {
+        this.project = project;
+    }
+}

--- a/src/main/java/edu/unc/lib/boxc/migration/cdm/validators/AspaceRefIdValidator.java
+++ b/src/main/java/edu/unc/lib/boxc/migration/cdm/validators/AspaceRefIdValidator.java
@@ -22,6 +22,10 @@ import java.util.regex.Pattern;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
+/**
+ * Validator for aspace ref id mappings
+ * @author krwong
+ */
 public class AspaceRefIdValidator {
     private static final Logger log = getLogger(AspaceRefIdValidator.class);
     private MigrationProject project;

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/AspaceRefIdCommandIT.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/AspaceRefIdCommandIT.java
@@ -13,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -49,6 +50,35 @@ public class AspaceRefIdCommandIT extends AbstractCommandIT {
         assertTrue(Files.exists(project.getAspaceRefIdMappingPath()));
 
         assertUpdatedDatePresent();
+    }
+
+    @Test
+    public void validateValidTest() throws Exception {
+        indexExportSamples();
+        writeCsv(mappingBody("25,fcee5fc2bb61effc8836498a8117b05d"));
+
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "aspace_ref_id", "validate" };
+        executeExpectSuccess(args);
+
+        assertOutputContains("PASS: Aspace ref id mapping at path " + project.getAspaceRefIdMappingPath() + " is valid");
+    }
+
+    @Test
+    public void validateInvalidTest() throws Exception {
+        indexExportSamples();
+        writeCsv(mappingBody("25,"));
+
+        String[] args = new String[] {
+                "-w", project.getProjectPath().toString(),
+                "aspace_ref_id", "validate" };
+        executeExpectFailure(args);
+
+        assertOutputContains("FAIL: Aspace ref id mapping at path " + project.getAspaceRefIdMappingPath()
+                + " is invalid");
+        assertOutputContains("- No aspace ref id mapped at line 2");
+        assertEquals(2, output.split("    - ").length, "Must only be two errors: " + output);
     }
 
     private void indexExportSamples() throws Exception {

--- a/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/AspaceRefIdValidatorTest.java
+++ b/src/test/java/edu/unc/lib/boxc/migration/cdm/validators/AspaceRefIdValidatorTest.java
@@ -1,0 +1,127 @@
+package edu.unc.lib.boxc.migration.cdm.validators;
+
+import edu.unc.lib.boxc.migration.cdm.exceptions.MigrationException;
+import edu.unc.lib.boxc.migration.cdm.model.AspaceRefIdInfo;
+import edu.unc.lib.boxc.migration.cdm.model.MigrationProject;
+import edu.unc.lib.boxc.migration.cdm.services.AspaceRefIdService;
+import edu.unc.lib.boxc.migration.cdm.services.MigrationProjectFactory;
+import edu.unc.lib.boxc.migration.cdm.test.BxcEnvironmentHelper;
+import edu.unc.lib.boxc.migration.cdm.test.CdmEnvironmentHelper;
+import edu.unc.lib.boxc.migration.cdm.test.SipServiceHelper;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AspaceRefIdValidatorTest {
+    private static final String PROJECT_NAME = "proj";
+    private static final String USERNAME = "migr_user";
+    @TempDir
+    public Path tmpFolder;
+
+    private MigrationProject project;
+    private AspaceRefIdValidator validator;
+    private SipServiceHelper testHelper;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        project = MigrationProjectFactory.createCdmMigrationProject(
+                tmpFolder, PROJECT_NAME, null, USERNAME,
+                CdmEnvironmentHelper.DEFAULT_ENV_ID, BxcEnvironmentHelper.DEFAULT_ENV_ID);
+
+        testHelper = new SipServiceHelper(project, tmpFolder);
+
+        validator = new AspaceRefIdValidator();
+        validator.setProject(project);
+    }
+
+    @Test
+    public void noMappingFileTest() throws Exception {
+        Assertions.assertThrows(MigrationException.class, () -> {
+            validator.validateMappings(false);
+        });
+    }
+
+    @Test
+    public void noEntriesTest() throws Exception {
+        writeCsv(mappingBody());
+        List<String> errors = validator.validateMappings(false);
+        assertHasError(errors, "Mappings file contained no mappings");
+        assertNumberErrors(errors, 1);
+    }
+
+    @Test
+    public void blankIdTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        writeCsv(mappingBody(",fcee5fc2bb61effc8836498a8117b05d"));
+        List<String> errors = validator.validateMappings(false);
+        assertHasError(errors, "Invalid blank id at line 2");
+        assertNumberErrors(errors, 1);
+    }
+
+    @Test
+    public void blankRefIdTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        writeCsv(mappingBody("25,"));
+        List<String> errors = validator.validateMappings(false);
+        assertHasError(errors, "No aspace ref id mapped at line 2");
+        assertNumberErrors(errors, 1);
+    }
+
+    @Test
+    public void tooFewColumnsTest() throws Exception {
+        writeCsv(mappingBody("25"));
+        List<String> errors = validator.validateMappings(false);
+        assertHasError(errors, "Invalid entry at line 2, must be 2 columns but were 1");
+        // Registers as having no mappings
+        assertNumberErrors(errors, 2);
+    }
+
+    @Test
+    public void tooManyColumnsTest() throws Exception {
+        writeCsv(mappingBody("25,,"));
+        List<String> errors = validator.validateMappings(false);
+        assertHasError(errors, "Invalid entry at line 2, must be 2 columns but were 3");
+        // Registers as having no mappings
+        assertNumberErrors(errors, 2);
+    }
+
+    @Test
+    public void duplicateIdTest() throws Exception {
+        testHelper.indexExportData("mini_gilmer");
+        writeCsv(mappingBody("25,fcee5fc2bb61effc8836498a8117b05d",
+                "25,fcee5fc2bb61effc8836498a8117b05d"));
+        List<String> errors = validator.validateMappings(false);
+        assertHasError(errors, "Duplicate mapping for id 25 at line 3");
+        assertNumberErrors(errors, 1);
+    }
+
+    private void assertHasError(List<String> errors, String expected) {
+        assertTrue(errors.contains(expected),
+                "Expected error:\n" + expected + "\nBut the returned errors were:\n" + String.join("\n", errors));
+    }
+
+    private String mappingBody(String... rows) {
+        return String.join(",", AspaceRefIdInfo.CSV_HEADERS) + "\n"
+                + String.join("\n", rows);
+    }
+
+    private void writeCsv(String mappingBody) throws IOException {
+        FileUtils.write(project.getAspaceRefIdMappingPath().toFile(),
+                mappingBody, StandardCharsets.UTF_8);
+    }
+
+    private void assertNumberErrors(List<String> errors, int expected) {
+        assertEquals(expected, errors.size(),
+                "Incorrect number of errors:\n" + String.join("\n", errors));
+    }
+}


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4955](https://unclibrary.atlassian.net/browse/BXC-4955)

- add `AspaceRefIdValidator` to validate aspace ref id mappings
- add `validate` command to `AspaceRefIdCommand`
- add tests